### PR TITLE
fix: rule headings should resolve back ticks

### DIFF
--- a/src/components/layout/index.scss
+++ b/src/components/layout/index.scss
@@ -211,6 +211,9 @@ section.layout-container {
                 h2{
                   margin: 0;
                   margin-bottom: 0.5rem;
+                  >p{
+                    margin: 0;
+                  }
                 }
                 &:last-child{
                   border-bottom: none;

--- a/src/pages/rules.js
+++ b/src/pages/rules.js
@@ -31,7 +31,11 @@ export default ({ data }) => {
 								<section>
 									{/* rule id */}
 									<a href={slug.replace('rules/', '')}>
-										<h2>{name}</h2>
+										<h2
+											dangerouslySetInnerHTML={{
+												__html: converter.makeHtml(name),
+											}}
+										/>
 									</a>
 									{/* rule sc's */}
 									{getAccessibilityRequirements(accessibility_requirements, 'text')}

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -69,6 +69,9 @@
     padding: 2rem 0;
     margin-bottom: 0;
     text-decoration: none;
+    >p{
+      margin: 0;
+    }
   }
   h2, h3, h4, h5, h6 {
     &:hover {

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -40,7 +40,11 @@ export default ({ data }) => {
 				{/* rule content */}
 				<header>
 					{/* title */}
-					<h1>{frontmatter.name}</h1>
+					<h1
+						dangerouslySetInnerHTML={{
+							__html: converter.makeHtml(frontmatter.name),
+						}}
+					/>
 				</header>
 				{/* frontmatter */}
 				<ul className="meta">


### PR DESCRIPTION
This PR resolves back ticks on headings of rules.

Closes Issue:
- https://github.com/act-rules/act-rules-web/issues/17