### PR TITLE
refactor: update `layout` component

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -1,104 +1,63 @@
-import React from 'react'
+import React, { useState, useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
-import { StaticQuery, graphql, Link } from 'gatsby'
+import { useStaticQuery, graphql } from 'gatsby'
 import ReactMedia from 'react-media'
-
 import Navigation from '../navigation'
 import Footer from '../footer'
 
 import 'normalize.css'
 import './index.scss'
 
-class Layout extends React.Component {
-	constructor(props) {
-		super(props)
-		this.state = {
-			showMenu: true,
-		}
-	}
+const Layout = ({ children, location }) => {
+	const [showMenu, setShowMenu] = useState(true)
 
-	componentDidMount() {
-		const { hash } = window.location
-		if (!hash) {
+	const data = useStaticQuery(
+		graphql`
+			query {
+				getSiteTitle: site {
+					siteMetadata {
+						actRulesPackage
+					}
+				}
+			}
+		`
+	)
+
+	useLayoutEffect(() => {
+		/**
+		 * Scroll to anchor if specified
+		 */
+		if (!location || !location.hash) {
 			return
 		}
-		const el = document.getElementById(hash)
+		const el = document.querySelector(location.hash)
 		if (!el) {
 			return
 		}
 		el.scrollIntoView()
-	}
+	})
 
-	handleHideShowMenu() {
-		this.setState(prevState => ({
-			showMenu: !prevState.showMenu,
-		}))
-	}
+	const { getSiteTitle } = data
+	const { author, repository } = JSON.parse(getSiteTitle.siteMetadata.actRulesPackage)
+	const { url: actRulesRepoUrl } = repository
 
-	getListItemFromEdges(edges) {
-		return edges.map(edge => {
-			const { node } = edge
-			const { path, context } = node
+	const handleHideShowMenu = () => setShowMenu(!showMenu)
 
-			if (!context || !context.title) {
-				return null
-			}
-
-			const key = `${context.title}${path}`
-			return (
-				<li key={key}>
-					<Link activeClassName="active" to={path}>
-						{context.title}
-					</Link>
-				</li>
-			)
-		})
-	}
-
-	render() {
-		const { children } = this.props
-		return (
-			<StaticQuery
-				query={graphql`
-					query {
-						getSiteTitle: site {
-							siteMetadata {
-								actRulesPackage
-							}
-						}
-					}
-				`}
-				render={data => {
-					const { getSiteTitle } = data
-					const {
-						author,
-						repository: { url: actRulesRepoUrl },
-					} = JSON.parse(getSiteTitle.siteMetadata.actRulesPackage)
-					return (
-						<section className="layout-container">
-							{/* hide menu when width <= 600px */}
-							<ReactMedia
-								query="(max-width: 600px)"
-								onChange={matches => matches && this.state.showMenu && this.handleHideShowMenu()}
-							/>
-							{/* show menu when width > 600px */}
-							<ReactMedia
-								query="(min-width: 601px)"
-								onChange={matches => matches && !this.state.showMenu && this.handleHideShowMenu()}
-							/>
-							{/* side bar navigation  */}
-							<Navigation logoName={author.name} logoNavigateTo={'/pages/about'} />
-							{/* main content  */}
-							<main>
-								<section>{children}</section>
-								<Footer actRulesRepoUrl={actRulesRepoUrl} />
-							</main>
-						</section>
-					)
-				}}
-			/>
-		)
-	}
+	return (
+		<section className="layout-container">
+			{/* hide menu when width <= 600px */}
+			<ReactMedia query="(max-width: 600px)" onChange={matches => matches && showMenu && handleHideShowMenu()} />
+			{/* show menu when width > 600px */}
+			<ReactMedia query="(min-width: 601px)" onChange={matches => matches && !showMenu && handleHideShowMenu()} />
+			{/* side bar navigation  */}
+			<Navigation logoName={author.name} logoNavigateTo={'/pages/about'} />
+			{/* main content  */}
+			<main>
+				<section>{children}</section>
+				<Footer actRulesRepoUrl={actRulesRepoUrl} />
+			</main>
+		</section>
+	)
 }
 
 Layout.propTypes = {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,8 +3,8 @@ import React from 'react'
 import Layout from '../components/layout/'
 import SEO from '../components/seo'
 
-const NotFoundPage = () => (
-	<Layout>
+const NotFoundPage = ({ location }) => (
+	<Layout location={location}>
 		<SEO title="404: Not found" />
 		<h1>NOT FOUND</h1>
 		<p>You just hit a route that doesn&#39;t exist... the sadness.</p>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -5,12 +5,12 @@ import SEO from '../components/seo'
 import { getGlossaryUsageInRules } from './../utils/render-fragments'
 import glossaryUsages from './../../_data/glossary-usages.json'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { glossaryData } = data
 	const { edges } = glossaryData
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title="Glossary" />
 			<section className="page-container page-glossary">
 				<h1>Glossary</h1>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import { graphql, useStaticQuery } from 'gatsby'
 import Layout from '../components/layout/'
 import SEO from '../components/seo'
 import glossaryUsages from './../../_data/glossary-usages.json'
 import ListWithHeading from '../components/list-with-heading'
 
-export default ({ data, location }) => {
+const Glossary = ({ data, location }) => {
 	const { glossaryData } = data
-	const { edges } = glossaryData
 
 	return (
 		<Layout location={location}>

--- a/src/pages/rules.js
+++ b/src/pages/rules.js
@@ -9,12 +9,12 @@ import {
 	getImplementationsCount,
 } from './../utils/render-fragments'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { rules, allRules } = data
 	const converter = new showdown.Converter()
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title="Rules" />
 			<section className="page-container page-rules">
 				{/* Heading */}

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -64,7 +64,7 @@ const getChangelogTabulation = (changelog, url, file) => {
 	)
 }
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { site, sitePage } = data
 	const { context } = sitePage
 	const { title: pageTitle, fastmatterAttributes, changelog, fileName } = context
@@ -80,7 +80,7 @@ export default ({ data }) => {
 	} = JSON.parse(site.siteMetadata.actRulesPackage)
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={pageTitle} />
 			<section className="page-container page-rule-changelog">
 				<h1>{pageTitle}</h1>

--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby'
 import SEO from '../components/seo'
 import glossaryUsages from './../../_data/glossary-usages.json'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { markdownRemark, site } = data
 	const {
 		www: { url },
@@ -37,7 +37,7 @@ export default ({ data }) => {
 	}, {})
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={frontmatter.title} />
 			<section className="page-container">
 				<h1>{frontmatter.title}</h1>

--- a/src/templates/glossary.js
+++ b/src/templates/glossary.js
@@ -3,12 +3,12 @@ import Layout from '../components/layout/'
 import { graphql } from 'gatsby'
 import SEO from '../components/seo'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { markdownRemark } = data
 	const { html, frontmatter } = markdownRemark
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={frontmatter.title} />
 			<div>
 				<h1>{frontmatter.title}</h1>

--- a/src/templates/implementations.js
+++ b/src/templates/implementations.js
@@ -5,12 +5,12 @@ import SEO from '../components/seo'
 import implementers from './../../_data/implementers'
 import { getImplementationsTabulation } from './../utils/render-fragments'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { markdownRemark } = data
 	const { html, frontmatter } = markdownRemark
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={frontmatter.title} />
 			<section className="page-container">
 				<h1>{frontmatter.title}</h1>

--- a/src/templates/implementer.js
+++ b/src/templates/implementer.js
@@ -95,9 +95,9 @@ const getTabulatedImplementations = (ruleImplementations, showIncomplete) => {
 	)
 }
 
-const getPage = (pageTitle, pageContent) => {
+const getPage = (pageTitle, pageContent, location) => {
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={pageTitle} />
 			<section className="page-container page-implementers">
 				<h1>{pageTitle}</h1>
@@ -131,11 +131,11 @@ export default props => {
 				All implementations provided are incomplete. Kindly submit amended implementation reports.
 			</div>
 		)
-		return getPage(pageTitle, content)
+		return getPage(pageTitle, content, location)
 	}
 
 	const pageContent = getTabulatedImplementations(mapping, showIncomplete)
-	return getPage(pageTitle, pageContent)
+	return getPage(pageTitle, pageContent, location)
 }
 
 export const query = graphql`

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -17,7 +17,7 @@ import {
 import SEO from '../components/seo'
 import Acknowledgements from '../components/acknowledgements'
 
-export default ({ data }) => {
+export default ({ data, location }) => {
 	const { rule, allRules, allGlossary, site } = data
 	const { html, frontmatter, tableOfContents, fields } = rule
 	const { slug, fastmatterAttributes, changelog, fileName } = fields
@@ -34,7 +34,7 @@ export default ({ data }) => {
 	const ruleFormatInputAspects = config['rule-format-metadata']['input-aspects']
 
 	return (
-		<Layout>
+		<Layout location={location}>
 			<SEO title={`Rule | ${frontmatter.name}`} />
 			<section className="page-rule">
 				{/* rule content */}


### PR DESCRIPTION
- updated `layout` component to a functional component.
- Bound location via props from pages to component, given since Gatsby V2, location is only available on the pages and not in the components, and hence has to be passed/ bound.