### PR TITLE
fix: freeze act-map-generator to old version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,7 +1953,7 @@
 			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
 		},
 		"act-rules-community": {
-			"version": "git+https://github.com/act-rules/act-rules.github.io.git#26d6f127226013192dec839b035264067a3c96dd",
+			"version": "git+https://github.com/act-rules/act-rules.github.io.git#36974deafefd976ef3b60153f8387885904f1190",
 			"from": "git+https://github.com/act-rules/act-rules.github.io.git#develop",
 			"requires": {
 				"fastmatter": "^2.1.1",
@@ -1963,7 +1963,7 @@
 				"htmlhint": "^0.11.0",
 				"is-url": "^1.2.4",
 				"jest-expect-message": "^1.0.2",
-				"markdown-link-extractor": "^1.2.1",
+				"markdown-link-extractor": "^1.2.2",
 				"remove-markdown": "^0.3.0"
 			}
 		},
@@ -1980,7 +1980,7 @@
 			"from": "git+https://git@github.com/act-rules/act-rules-implementation-alfa.git"
 		},
 		"act-rules-implementation-axe-core": {
-			"version": "git+https://git@github.com/act-rules/act-rules-implementation-axe-core.git#6d78c88b33f96dbc9951c5367ac3ca3f2421afeb",
+			"version": "git+https://git@github.com/act-rules/act-rules-implementation-axe-core.git#bec0baee4076fb6f615d26a15339a38ecef9308a",
 			"from": "git+https://git@github.com/act-rules/act-rules-implementation-axe-core.git",
 			"requires": {
 				"assert": "^2.0.0",
@@ -1999,7 +1999,7 @@
 		},
 		"act-rules-implementation-mapper": {
 			"version": "git+https://git@github.com/act-rules/act-rules-implementation-mapper.git#b8562dfa8adb3c44ec005d253dfa6548196f81cd",
-			"from": "git+https://git@github.com/act-rules/act-rules-implementation-mapper.git",
+			"from": "git+https://git@github.com/act-rules/act-rules-implementation-mapper.git#b8562dfa8adb3c44ec005d253dfa6548196f81cd",
 			"requires": {
 				"axios": "^0.19.0",
 				"commander": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"act-rules-implementation-access-engine": "git+https://git@github.com/act-rules/act-rules-implementation-access-engine.git",
 		"act-rules-implementation-alfa": "git+https://git@github.com/act-rules/act-rules-implementation-alfa.git",
 		"act-rules-implementation-axe-core": "git+https://git@github.com/act-rules/act-rules-implementation-axe-core.git",
-		"act-rules-implementation-mapper": "git+https://git@github.com/act-rules/act-rules-implementation-mapper.git",
+		"act-rules-implementation-mapper": "git+https://git@github.com/act-rules/act-rules-implementation-mapper.git#b8562dfa8adb3c44ec005d253dfa6548196f81cd",
 		"act-rules-implementation-qualweb": "git+https://git@github.com/act-rules/act-rules-implementation-qualweb.git",
 		"act-rules-implementation-rgaa": "git+https://git@github.com/act-rules/act-rules-implementation-rgaa.git",
 		"act-rules-implementation-trusted-tester": "git+https://git@github.com/act-rules/act-rules-implementation-trusted-tester.git",


### PR DESCRIPTION
Given [act-implementation-mapper](https://github.com/act-rules/act-rules-implementation-mapper) has matured & the current website code adaptation has not been merged yet, see PR https://github.com/act-rules/act-rules-web/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc

It makes sense to fix the `act-implementation-mapper` to a specific [version](https://github.com/act-rules/act-rules-implementation-mapper/commit/b8562dfa8adb3c44ec005d253dfa6548196f81cd), to allow for passing builds