### PR TITLE
fix: Remove cursor:pointer from header-style mixin

### DIFF
--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -29,7 +29,6 @@
 	text-decoration: none;
 	margin: 1rem 0;
 	display: block;
-	cursor: pointer;
 }
 
 @mixin reset-list() {


### PR DESCRIPTION
While it's true that most elements that use this mixin are also interactive, it is also used on static elements ... and here, having the explicit `cursor:pointer` mouse cursor (the "hand" one) is misleading and confusing, as it makes those static elements appear to be interactive/clickable to sighted mouse users.

Closes #54
Closes #69