### PR TITLE
fix: remove listing of manual rules

### DIFF
--- a/gatsby/create-page-implementer-report.js
+++ b/gatsby/create-page-implementer-report.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const yaml = require('js-yaml')
-const manualRules = yaml.safeLoad(fs.readFileSync('./manual-rules.yml', 'utf8'))
 
 const implementers = require('../_data/implementers.json')
 const getTemplate = require('./get-template')
@@ -23,7 +22,6 @@ const createPageImplementerReport = ({ actions: { createPage } }) => {
 				filename,
 				title: `Implementation report of ${toolName} (${organisation})`,
 				implementerData: JSON.stringify(impl),
-				manualRules
 			},
 		})
 
@@ -38,7 +36,6 @@ const createPageImplementerReport = ({ actions: { createPage } }) => {
 				filename,
 				title: `Incomplete implementations report of ${toolName} (${organisation})`,
 				implementerData: JSON.stringify(impl),
-				manualRules
 			},
 		})
 	}

--- a/manual-rules.yml
+++ b/manual-rules.yml
@@ -1,9 +1,0 @@
-# List of ids of rules whose testing methodology is manual
-
-- e6952f # Attribute is not duplicated
-- 80af7b # Focusable element has no keyboard trap
-- ebe86a # Focusable element has no keyboard trap via non-standard navigation
-- a1b64e # Focusable element has no keyboard trap via standard navigation
-- cc0f0a # Form control label is descriptive
-- c4a8a4 # HTML page title is descriptive
-- b49b2e # Heading is descriptive

--- a/src/templates/implementer-incomplete.js
+++ b/src/templates/implementer-incomplete.js
@@ -12,7 +12,7 @@ import Badge from '../components/badge'
 import './implementer-incomplete.scss'
 
 const ImplementerIncomplete = ({ location, data }) => {
-	const { title, implementerData, manualRules } = data.sitePage.context
+	const { title, implementerData } = data.sitePage.context
 	const { actMapping } = JSON.parse(implementerData)
 	const completeMaps = filterByConsistency(actMapping, ['consistent', 'partially-consistent'])
 	const incompleteMaps = filterByConsistency(actMapping, ['inconsistent'])
@@ -57,7 +57,6 @@ const ImplementerIncomplete = ({ location, data }) => {
 								<RuleHeader ruleId={id} ruleName={name}>
 									<Badge title={`Id:`} value={id} />
 									<Badge title={`Type:`} value={rule_type} />
-									{manualRules.includes(id) && <Badge title={`Mode:`} value={`manual`} />}
 								</RuleHeader>
 								<AccessibilityRequirements accessibility_requirements={accessibility_requirements} type="text" />
 							</div>
@@ -72,7 +71,6 @@ const ImplementerIncomplete = ({ location, data }) => {
 							<RuleHeader ruleId={id} ruleName={name}>
 								<Badge title={`Id:`} value={id} />
 								<Badge title={`Type:`} value={rule_type} />
-								{manualRules.includes(id) && <Badge title={`Mode:`} value={`manual`} />}
 							</RuleHeader>
 							<ListOfImplementations mapping={[impl]} showIncomplete={true} />
 						</div>
@@ -92,7 +90,6 @@ export const query = graphql`
 				filename
 				title
 				implementerData
-				manualRules
 			}
 		}
 		allRules: allMarkdownRemark(


### PR DESCRIPTION
It is not essential to keep a list of manual rules in the website.

Closes:
- https://github.com/act-rules/act-rules-web/issues/99