### PR TITLE
chore: create a zip of testcases and its assets

### DIFF
--- a/build/create-testcases.js
+++ b/build/create-testcases.js
@@ -7,6 +7,7 @@ const createTestcasesJson = require('./testcases/create-testcases-json')
 const createTestcasesOfRuleOfEmReportTool = require('./testcases/create-testcases-of-rule-of-em-report-tool')
 const getMarkdownData = require('../utils/get-markdown-data')
 const getMarkdownAstNodesOfType = require('../utils/get-markdown-ast-nodes-of-type')
+const createZip = require('../utils/create-zip')
 
 /**
  * Parse `args`
@@ -104,7 +105,7 @@ async function init(program) {
 			/**
 			 * Create testcase file
 			 */
-			await createFile(`${outputDir}/rules-testcases/${testcasePath}`, codeWithDoctype)
+			await createFile(`${outputDir}/${testcasePath}`, codeWithDoctype)
 
 			/**
 			 * Create meta data for testcase(s)
@@ -136,7 +137,8 @@ async function init(program) {
 				ruleTestcases,
 				ruleAccessibilityRequirements,
 			},
-			actRulesCommunityPkg
+			actRulesCommunityPkg,
+			outputDir
 		)
 	}
 
@@ -144,12 +146,17 @@ async function init(program) {
 	 * Copy test assets that are used by `testcases`
 	 */
 	const assetsDirName = testAssetsDir.split('/').pop()
-	await copy(`${testAssetsDir}`, `${outputDir}/rules-testcases/${assetsDirName}`)
+	await copy(`${testAssetsDir}`, `${outputDir}/${assetsDirName}`)
 
 	/**
 	 * Generate `testcases.json`
 	 */
-	await createTestcasesJson(allRulesTestcases, actRulesCommunityPkg)
+	await createTestcasesJson(allRulesTestcases, actRulesCommunityPkg, outputDir)
+
+	/**
+	 * Zip up the testcases and assets directory
+	 */
+	await createZip(outputDir, `_data/testcases.zip`)
 }
 
 function wrapCodeWithDoctype(lang, code) {

--- a/build/create-testcases.js
+++ b/build/create-testcases.js
@@ -7,7 +7,6 @@ const createTestcasesJson = require('./testcases/create-testcases-json')
 const createTestcasesOfRuleOfEmReportTool = require('./testcases/create-testcases-of-rule-of-em-report-tool')
 const getMarkdownData = require('../utils/get-markdown-data')
 const getMarkdownAstNodesOfType = require('../utils/get-markdown-ast-nodes-of-type')
-const createZip = require('../utils/create-zip')
 
 /**
  * Parse `args`
@@ -152,11 +151,6 @@ async function init(program) {
 	 * Generate `testcases.json`
 	 */
 	await createTestcasesJson(allRulesTestcases, actRulesCommunityPkg, outputDir)
-
-	/**
-	 * Zip up the testcases and assets directory
-	 */
-	await createZip(outputDir, `_data/testcases.zip`)
 }
 
 function wrapCodeWithDoctype(lang, code) {

--- a/build/testcases/create-testcases-json.js
+++ b/build/testcases/create-testcases-json.js
@@ -3,7 +3,7 @@ const createFile = require('../../utils/create-file')
 /**
  * Create `testcases.json`
  */
-const createTestcasesJson = async (testcases, actRulesCommunityPkg) => {
+const createTestcasesJson = async (testcases, actRulesCommunityPkg, outputDir) => {
 	const {
 		www: { url },
 		author,
@@ -18,7 +18,7 @@ const createTestcasesJson = async (testcases, actRulesCommunityPkg) => {
 		testcases,
 	}
 
-	await createFile(`_data/rules-testcases/testcases.json`, JSON.stringify(AllTestcasesData, undefined, 2))
+	await createFile(`${outputDir}/testcases.json`, JSON.stringify(AllTestcasesData, undefined, 2))
 }
 
 module.exports = createTestcasesJson

--- a/build/testcases/create-testcases-of-rule-of-em-report-tool.js
+++ b/build/testcases/create-testcases-of-rule-of-em-report-tool.js
@@ -8,7 +8,7 @@ const createFile = require('../../utils/create-file')
 /**
  * Create testcases json file that can be used by
  */
-const createTestcasesOfRuleOfEmReportTool = async (options, actRulesCommunityPkg) => {
+const createTestcasesOfRuleOfEmReportTool = async (options, actRulesCommunityPkg, outputDir) => {
 	const { ruleId, ruleName, ruleTestcases, ruleAccessibilityRequirements } = options
 	const {
 		www: { url },
@@ -82,7 +82,7 @@ const createTestcasesOfRuleOfEmReportTool = async (options, actRulesCommunityPkg
 	}
 
 	await createFile(
-		`_data/rules-testcases/testcases/${ruleId}/rule-${ruleId}-testcases-for-em-report-tool.json`,
+		`${outputDir}/testcases/${ruleId}/rule-${ruleId}-testcases-for-em-report-tool.json`,
 		JSON.stringify(json, undefined, 2)
 	)
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,12 @@ exports.onPreBootstrap = async () => {
 	 * Note:
 	 * `gatsby build` cleans all `html` and `css` files within the destination directory, hence the need to copy these during `bootstrap` step
 	 */
-	await copy('./_data/rules-testcases', 'public')
+	await copy('./_data/testcases', 'public')
+
+	/**
+	 * copy `testcases.zip`
+	 */
+	await copy('./_data/testcases.zip', 'public')
 
 	/**
 	 * copy `earl-context.json` so it can be available in URL - `https://act-rules.github.io/earl-context.json`

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,7 @@
 const { copy } = require('fs-extra')
 const onCreateNode = require('./gatsby/on-create-node')
 const createPages = require('./gatsby/create-pages')
+const createZip = require('./utils/create-zip')
 
 exports.onPreBootstrap = async () => {
 	/**
@@ -9,11 +10,7 @@ exports.onPreBootstrap = async () => {
 	 * `gatsby build` cleans all `html` and `css` files within the destination directory, hence the need to copy these during `bootstrap` step
 	 */
 	await copy('./_data/testcases', 'public')
-
-	/**
-	 * copy `testcases.zip`
-	 */
-	await copy('./_data/testcases.zip', 'public')
+	await createZip('./_data/testcases', 'public/testcases.zip')
 
 	/**
 	 * copy `earl-context.json` so it can be available in URL - `https://act-rules.github.io/earl-context.json`

--- a/implementations.yml
+++ b/implementations.yml
@@ -3,35 +3,35 @@
 - organisation: 'Access42'
   toolName: 'RGAA 3.0'
   jsonReports: ./node_modules/act-rules-implementation-rgaa/reports/*.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/rgaa.json
 
 - organisation: 'Deque Systems'
   toolName: 'Axe Core'
   jsonReports: ./node_modules/act-rules-implementation-axe-core/report.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/axe.json
 
 - organisation: 'LASIGE, Faculdade de Ciências da Universidade de Lisboa'
   toolName: 'QualWeb'
   jsonReports: ./node_modules/act-rules-implementation-qualweb/reports/*.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/qualweb.json
 
 - organisation: 'Level Access'
   toolName: 'Access Engine'
   jsonReports: ./node_modules/act-rules-implementation-access-engine/report.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/access-engine.json
 
 - organisation: 'Siteimprove'
   toolName: 'Alfa'
   jsonReports: ./node_modules/act-rules-implementation-alfa/report.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/alfa.json
 
 - organisation: 'Trusted Tester'
   toolName: 'Trusted Tester'
   jsonReports: ./node_modules/act-rules-implementation-trusted-tester/reports/*.json
-  testcases: ./_data/rules-testcases/testcases.json
+  testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/trusted-tester.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2804,6 +2804,91 @@
 				}
 			}
 		},
+		"archiver": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-0.11.0.tgz",
+			"integrity": "sha1-mBd9p6bAGSt/J5jzDNbquKvXZpA=",
+			"requires": {
+				"async": "~0.9.0",
+				"buffer-crc32": "~0.2.1",
+				"glob": "~3.2.6",
+				"lazystream": "~0.1.0",
+				"lodash": "~2.4.1",
+				"readable-stream": "~1.0.26",
+				"tar-stream": "~0.4.0",
+				"zip-stream": "~0.4.0"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.9.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+				},
+				"bl": {
+					"version": "0.9.5",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+					"integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+					"requires": {
+						"readable-stream": "~1.0.26"
+					}
+				},
+				"glob": {
+					"version": "3.2.11",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+					"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+					"requires": {
+						"inherits": "2",
+						"minimatch": "0.3"
+					}
+				},
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+				},
+				"lru-cache": {
+					"version": "2.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+				},
+				"minimatch": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+					"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+					"requires": {
+						"lru-cache": "2",
+						"sigmund": "~1.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"tar-stream": {
+					"version": "0.4.7",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+					"integrity": "sha1-Hx0s6evHtCdlJDyg6PG3v9oKrc0=",
+					"requires": {
+						"bl": "^0.9.0",
+						"end-of-stream": "^1.0.0",
+						"readable-stream": "^1.0.27-1",
+						"xtend": "^4.0.0"
+					}
+				}
+			}
+		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -5127,6 +5212,34 @@
 			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
 		},
+		"compress-commons": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
+			"integrity": "sha1-DHQIcP3ljLpRbwrAyCLjOguF36M=",
+			"requires": {
+				"buffer-crc32": "~0.2.1",
+				"crc32-stream": "~0.3.1",
+				"readable-stream": "~1.0.26"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
 		"compressible": {
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
@@ -5510,6 +5623,33 @@
 						"json-parse-better-errors": "^1.0.1",
 						"lines-and-columns": "^1.1.6"
 					}
+				}
+			}
+		},
+		"crc32-stream": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
+			"integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
+			"requires": {
+				"buffer-crc32": "~0.2.1",
+				"readable-stream": "~1.0.24"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},
@@ -14926,6 +15066,32 @@
 				"package-json": "^6.3.0"
 			}
 		},
+		"lazystream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
+			"integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
+			"requires": {
+				"readable-stream": "~1.0.2"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
+			}
+		},
 		"lcid": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -21243,6 +21409,11 @@
 			"resolved": "https://registry.npmjs.org/sift/-/sift-5.1.0.tgz",
 			"integrity": "sha1-G78t+w63HlbEzH+1Z/vRNRtlAV4="
 		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -24876,6 +25047,47 @@
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
+				}
+			}
+		},
+		"zip-folder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/zip-folder/-/zip-folder-1.0.0.tgz",
+			"integrity": "sha1-cKd0T9F4mi/rQa00GbMun9h5V7I=",
+			"requires": {
+				"archiver": "^0.11.0"
+			}
+		},
+		"zip-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
+			"integrity": "sha1-TqeVqM4Z6fq0mjHR0IdyFBWfA6M=",
+			"requires": {
+				"compress-commons": "~0.1.0",
+				"lodash": "~2.4.1",
+				"readable-stream": "~1.0.26"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 		"remark": "^11.0.2",
 		"remove-markdown": "^0.3.0",
 		"showdown": "^1.9.1",
-		"unist-util-visit": "^2.0.1"
+		"unist-util-visit": "^2.0.1",
+		"zip-folder": "^1.0.0"
 	},
 	"devDependencies": {
 		"husky": "^3.1.0",
@@ -71,10 +72,10 @@
 	"license": "MIT",
 	"scripts": {
 		"getWcagMetaData": "node ./build/get-wcag-meta-data --url 'https://raw.githubusercontent.com/w3c/wai-wcag-quickref/gh-pages/_data/wcag21.json' --outputDir ${PWD}'/_data'",
-		"createTestcases": "node ./build/create-testcases --rulesDir $npm_package_config_actRulesCommunityRulesDir --testAssetsDir $npm_package_config_actRulesCommunityTestAssetsDir --actRulesCommunityPkgJson ${PWD}/$npm_package_config_actRulesCommunityPkgJson --outputDir ${PWD}'/_data'",
+		"createTestcases": "node ./build/create-testcases --rulesDir $npm_package_config_actRulesCommunityRulesDir --testAssetsDir $npm_package_config_actRulesCommunityTestAssetsDir --actRulesCommunityPkgJson ${PWD}/$npm_package_config_actRulesCommunityPkgJson --outputDir ${PWD}'/_data/testcases'",
 		"createGlossaryUsages": "node ./build/create-glossary-usages --rulesDir $npm_package_config_actRulesCommunityRulesDir --outputDir ${PWD}'/_data'",
 		"createRulesUsages": "node ./build/create-rules-usages.js --rulesDir $npm_package_config_actRulesCommunityRulesDir --outputDir ${PWD}'/_data'",
-		"pregetImplementationAxeCore": "npm --prefix './node_modules/act-rules-implementation-axe-core/' install && npm --prefix './node_modules/act-rules-implementation-axe-core/' run build -- --testsJson ${PWD}'/_data/rules-testcases/testcases.json' --testsDir ${PWD}'/_data/rules-testcases' --siteUrl $npm_package_www_url",
+		"pregetImplementationAxeCore": "npm --prefix './node_modules/act-rules-implementation-axe-core/' install && npm --prefix './node_modules/act-rules-implementation-axe-core/' run build -- --testsJson ${PWD}'/_data/testcases/testcases.json' --testsDir ${PWD}'/_data/testcases' --siteUrl $npm_package_www_url",
 		"getImplementations": "npm run pregetImplementationAxeCore && node ./build/get-implementations --implementationsFile './implementations.yml'",
 		"createImplementationsMetrics": "node ./build/create-implementation-metrics --implementations ${PWD}'/_data/implementations/*.json' --outputDir ${PWD}'/_data'",
 		"implementations": "npm run getImplementations && npm run createImplementationsMetrics",

--- a/utils/create-zip.js
+++ b/utils/create-zip.js
@@ -1,13 +1,11 @@
 const zipFolder = require('zip-folder')
 
 const createZip = (folder, name) => {
-	console.log(folder)
 	return new Promise((resolve, reject) => {
 		zipFolder(folder, name, err => {
 			if (err) {
 				reject(err)
 			}
-			console.log('111')
 			resolve()
 		})
 	})

--- a/utils/create-zip.js
+++ b/utils/create-zip.js
@@ -1,0 +1,16 @@
+const zipFolder = require('zip-folder')
+
+const createZip = (folder, name) => {
+	console.log(folder)
+	return new Promise((resolve, reject) => {
+		zipFolder(folder, name, err => {
+			if (err) {
+				reject(err)
+			}
+			console.log('111')
+			resolve()
+		})
+	})
+}
+
+module.exports = createZip


### PR DESCRIPTION
Zip all testcases html files along with their assets. This will allow for the various implementers to have easier access to them, than just the testcases.json.

> Note: Need to update documentation and add a link to download this zip (this will happen in a different repo).