### PR TITLE
test: remove linkinator which verifies for broken links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,5 @@ jobs:
 
       - name: Build Gatsby website
         run: npm run build
-
-      - name: Verify broken links
-        run: npx linkinator ./public
-
         env:
           CI: true


### PR DESCRIPTION
It looks like this never worked & this is not built to work for SPA. 

![image](https://user-images.githubusercontent.com/20978252/73450441-4cef6b80-435d-11ea-9d6c-6c481bd33041.png)

This is not what we intend to test for broken links. A better solution needs to be found.