### PR TITLE
fix: use unified to ensure markdownAST is computed correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,27 +5,50 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.4.tgz",
+			"integrity": "sha512-lHLhlsvFjJAqNU71b7k6Vv9ewjmTXKvqaMv7n0G1etdCabWLw3nEYE8mmgoVOxMIFE07xOvo7H7XBASirX6Rrg==",
+			"requires": {
+				"browserslist": "^4.8.5",
+				"invariant": "^2.2.4",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
+					}
+				}
 			}
 		},
 		"@babel/core": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
-			"integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+			"integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.7",
-				"@babel/helpers": "^7.7.4",
-				"@babel/parser": "^7.7.7",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.8.4",
+				"@babel/helpers": "^7.8.4",
+				"@babel/parser": "^7.8.4",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.4",
+				"@babel/types": "^7.8.3",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.0",
 				"lodash": "^4.17.13",
 				"resolve": "^1.3.2",
@@ -41,11 +64,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-			"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+			"integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
 			"requires": {
-				"@babel/types": "^7.7.4",
+				"@babel/types": "^7.8.3",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
 				"source-map": "^0.5.0"
@@ -59,223 +82,247 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
-			"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.7.4.tgz",
-			"integrity": "sha512-Biq/d/WtvfftWZ9Uf39hbPBYDUo986m5Bb4zhkeYDGUllF43D+nUe5M6Vuo6/8JDK/0YX/uBdeoQpyaNhNugZQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
 			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-explode-assignable-expression": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-builder-react-jsx": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.4.tgz",
-			"integrity": "sha512-kvbfHJNN9dg4rkEM4xn1s8d1/h6TYNvajy9L1wx4qLn9HFg0IkTsQi4rfBe92nxrPUFcMsHoMV+8rU7MJb3fCA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.8.3.tgz",
+			"integrity": "sha512-JT8mfnpTkKNCboTqZsQTdGo3l3Ik3l7QIt9hh0O9DYiwVel37VoJpILKM4YFbP2euF32nkQSb+F9cUk9b7DDXQ==",
 			"requires": {
-				"@babel/types": "^7.7.4",
+				"@babel/types": "^7.8.3",
 				"esutils": "^2.0.0"
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.7.4.tgz",
-			"integrity": "sha512-8JH9/B7J7tCYJ2PpWVpw9JhPuEVHztagNVuQAFBVFYluRMlpG7F1CgKEgGeL6KFqcsIa92ZYVj6DSc0XwmN1ZA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.3.tgz",
+			"integrity": "sha512-6Q05px0Eb+N4/GTyKPPvnkig7Lylw+QzihMpws9iiZQv7ZImf84ZsZpQH7QoWN4n4tm81SnSzPgHw2qtO0Zf3A==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-hoist-variables": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.4.tgz",
+			"integrity": "sha512-3k3BsKMvPp5bjxgMdrFyq0UaEO48HciVrOVF0+lon8pp95cyJ2ujAh0TrBHNMnJGT2rr0iKOJPFFbSqjDyf/Pg==",
+			"requires": {
+				"@babel/compat-data": "^7.8.4",
+				"browserslist": "^4.8.5",
+				"invariant": "^2.2.4",
+				"levenary": "^1.1.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
+					"requires": {
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
+					}
+				}
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.7.4.tgz",
-			"integrity": "sha512-l+OnKACG4uiDHQ/aJT8dwpR+LhCJALxL0mJ6nzjB25e5IPwqV1VOsY7ah6UB1DG+VOXAIMtuC54rFJGiHkxjgA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.3.tgz",
+			"integrity": "sha512-qmp4pD7zeTxsv0JNecSBsEmG1ei2MqwJq4YQcK3ZWm/0t07QstWfvuV/vm3Qt5xNMFETn2SZqpMx2MQzbtq+KA==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-member-expression-to-functions": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
-			"integrity": "sha512-Mt+jBKaxL0zfOIWrfQpnfYCN7/rS6GKx6CCCfuoqVVd+17R8zNDlzVYmIi9qyb2wOk002NsmSTDymkIygDUH7A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.3.tgz",
+			"integrity": "sha512-Gcsm1OHCUr9o9TcJln57xhWHtdXbA2pgQ58S0Lxlks0WMGNXuki4+GLfX0p+L2ZkINUGZvfkz8rzoqJQSthI+Q==",
 			"requires": {
-				"@babel/helper-regex": "^7.4.4",
+				"@babel/helper-regex": "^7.8.3",
 				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.7.4.tgz",
-			"integrity": "sha512-v5LorqOa0nVQUvAUTUF3KPastvUt/HzByXNamKQ6RdJRTV7j8rLL+WB5C/MzzWAwOomxDhYFb1wLLxHqox86lg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/types": "^7.8.3",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.7.4.tgz",
-			"integrity": "sha512-2/SicuFrNSXsZNBxe5UGdLr+HZg+raWBLE9vC98bdYOKX/U6PY0mdGlYUJdtTDPSU0Lw0PNbKKDpwYHJLn2jLg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
 			"requires": {
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-			"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+			"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-			"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.7.4.tgz",
-			"integrity": "sha512-wQC4xyvc1Jo/FnLirL6CEgPgPCa8M74tOdjWpRhQYapz5JC7u3NYU1zCVoVAGCE3EaIP9T1A3iW0WLJ+reZlpQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
-			"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
-			"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
-			"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.3.tgz",
+			"integrity": "sha512-C7NG6B7vfBa/pwCOshpMbOYUmrYQDfCpVL/JCRu0ek8B5p8kue1+BCXpg2vOYs7w5ACB9GTOBYQ5U6NwrMg+3Q==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-simple-access": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
-			"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
-			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 		},
 		"@babel/helper-regex": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.5.5.tgz",
-			"integrity": "sha512-CkCYQLkfkiugbRDO8eZn6lRuR8kzZoGXCg3149iTk5se7g6qykSpy3+hELSwquhu+TgHn8nkLiBwHvNX8Hofcw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
 			"requires": {
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
-			"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-wrap-function": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-wrap-function": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
-			"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.3.tgz",
+			"integrity": "sha512-xOUssL6ho41U81etpLoT2RTdvdus4VfHamCuAm4AHxGr+0it5fnwoVdwUJ7GFEqCsQYzJUhcbsN9wB9apcYKFA==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.7.4.tgz",
-			"integrity": "sha512-zK7THeEXfan7UlWsG2A6CI/L9jVnI5+xxKZOdej39Y0YtDYKx9raHk5F2EtK9K8DHRTihYwg20ADt9S36GR78A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
 			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-			"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
 			"requires": {
-				"@babel/types": "^7.7.4"
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
-			"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
-			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+			"integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
 			"requires": {
-				"@babel/template": "^7.7.4",
-				"@babel/traverse": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.4",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -311,624 +358,631 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-			"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+			"integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.7.4.tgz",
-			"integrity": "sha512-1ypyZvGRXriY/QP668+s8sFr2mqinhkRDMPSQLNghCQE+GAkFtp+wkHVvg2+Hdki8gwP+NFzJBJ/N1BfzCCDEw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.4",
-				"@babel/plugin-syntax-async-generators": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-class-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.7.4.tgz",
-			"integrity": "sha512-EcuXeV4Hv1X3+Q1TsuOmyyxeTRiSqurGJ26+I/FW1WbymmRRapVORm6x1Zl3iDIHyRxEs+VXWp6qnlcfcJSbbw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+			"integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-class-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.7.4.tgz",
-			"integrity": "sha512-StH+nGAdO6qDB1l8sZ5UBV8AC3F2VW2I8Vfld73TMKyptMU9DY5YsJAS8U81+vEtxcH3Y/La0wG0btDrhpnhjQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-json-strings": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.7.4.tgz",
-			"integrity": "sha512-wQvt3akcBTfLU/wYoqm/ws7YOAQKu8EVJEvHip/mzkNtjaclQoCCIqKXFP5/eyfnfbQCDV3OLRIK3mIVyXuZlw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-json-strings": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-nullish-coalescing-operator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
-			"integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.7.tgz",
-			"integrity": "sha512-3qp9I8lelgzNedI3hrhkvhaEYree6+WHnyA/q4Dza9z7iEIs1eyhWyJnetk3jJ69RT0AT4G0UhEGwyGFJ7GUuQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-DyM7U2bnsQerCQ+sejcTNZh8KQEUuC3ufzdnVnSiUv/qoGJp2Z3hanKL18KDhsBT5Wj6a7CMT5mdyCNJsEaA9w==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
-			"integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-optional-chaining": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz",
-			"integrity": "sha512-80PbkKyORBUVm1fbTLrHpYdJxMThzM1UqFGh0ALEhO9TYbG86Ah9zQYAB/84axz2vcxefDLdZwWwZNlYARlu9w==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
+			"integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.7.4.tgz",
-			"integrity": "sha512-Li4+EjSpBgxcsmeEF8IFcfV/+yJGxHXDirDkEoyFjumuwbmfCVHUt0HuowD/iGM7OhIRyXJH9YXxqiH6N815+g==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-dynamic-import": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.7.4.tgz",
-			"integrity": "sha512-jHQW0vbRGvwQNgyVxwDh4yuXu4bH1f5/EICJLAhl1SblLs2CDhrsmCk+v5XLdE9wxtAFRyxx+P//Iw+a5L/tTg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-json-strings": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.7.4.tgz",
-			"integrity": "sha512-QpGupahTQW1mHRXddMG5srgpHWqRLwJnJZKXTigB9RPFCCGbDGCgBeM/iC82ICXp414WeYx/tD54w7M2qRqTMg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-jsx": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.7.4.tgz",
-			"integrity": "sha512-wuy6fiMe9y7HeZBWXYCGt2RGxZOj0BImZ9EyXJVnVGBKO/Br592rbR3rtIQn0eQhAk9vqaKP5n8tVqEFBQMfLg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+			"integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-syntax-nullish-coalescing-operator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
-			"integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-object-rest-spread": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
-			"integrity": "sha512-mObR+r+KZq0XhRVS2BrBKBpr5jqrqzlPvS9C9vuOf5ilSwzloAl7RPWLrgKdWS6IreaVrjHxTjtyqFiOisaCwg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-catch-binding": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
-			"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-optional-chaining": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
-			"integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
 		"@babel/plugin-syntax-top-level-await": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.7.4.tgz",
-			"integrity": "sha512-wdsOw0MvkL1UIgiQ/IFr3ETcfv1xb8RMM0H9wbiDyLaJFyiDg5oZvDLCXosIXmFeIlweML5iOBXAkqddkYNizg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.7.4.tgz",
-			"integrity": "sha512-zUXy3e8jBNPiffmqkHRNDdZM2r8DWhCB7HhcoyZjiK1TxYEluLHAvQuYnTT+ARqRpabWqy/NHkO6e3MsYB5YfA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
-			"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.7.4"
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
-			"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
-			"integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.7.4.tgz",
-			"integrity": "sha512-sK1mjWat7K+buWRuImEzjNf68qrKcrddtpQo3swi9j7dUcG6y6R6+Di039QN2bD1dykeswlagupEmpOatFHHUg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.3.tgz",
+			"integrity": "sha512-SjT0cwFJ+7Rbr1vQsvphAHwUHvSUPmMjMU/0P59G8U2HLFqSa082JO7zkbDNWs9kH/IUqpHI6xWNesGf8haF1w==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-define-map": "^7.7.4",
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-optimise-call-expression": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-define-map": "^7.8.3",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.7.4.tgz",
-			"integrity": "sha512-bSNsOsZnlpLLyQew35rl4Fma3yKWqK3ImWMSC/Nc+6nGjC9s5NFWAer1YQ899/6s9HxO2zQC1WoFNfkOqRkqRQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.7.4.tgz",
-			"integrity": "sha512-4jFMXI1Cu2aXbcXXl8Lr6YubCn6Oc7k9lLsu8v61TZh+1jny2BWmdtvY9zSUlLdGUvcy9DMAWyZEOqjsbeg/wA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
+			"integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.7.7.tgz",
-			"integrity": "sha512-b4in+YlTeE/QmTgrllnb3bHA0HntYvjz8O3Mcbx75UBPJA2xhb5A8nle498VhxSXJHQefjtQxpnLPehDJ4TRlg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.7.4.tgz",
-			"integrity": "sha512-g1y4/G6xGWMD85Tlft5XedGaZBCIVN+/P0bs6eabmcPP9egFleMAo65OOjlhcz1njpwagyY3t0nsQC9oTFegJA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.7.4.tgz",
-			"integrity": "sha512-MCqiLfCKm6KEA1dglf6Uqq1ElDIZwFuzz1WH5mTf8k2uQSxEJMbOIEh7IZv7uichr7PMfi5YVSrr1vz+ipp7AQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
 			"requires": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.7.4.tgz",
-			"integrity": "sha512-zZ1fD1B8keYtEcKF+M1TROfeHTKnijcVQm0yO/Yu1f7qoDoxEIc/+GX6Go430Bg84eM/xwPFp0+h4EbZg7epAA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.4.tgz",
+			"integrity": "sha512-iAXNlOWvcYUYoV8YIxwS7TxGRJcxyl8eQCfT+A5j8sKUzRFvJdcyjp97jL2IghWSRDaL2PU2O2tX8Cu9dTBq5A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.7.4.tgz",
-			"integrity": "sha512-E/x09TvjHNhsULs2IusN+aJNRV5zKwxu1cpirZyRPw+FyyIKEHPXTsadj48bVpc1R5Qq1B5ZkzumuFLytnbT6g==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
 			"requires": {
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.7.4.tgz",
-			"integrity": "sha512-X2MSV7LfJFm4aZfxd0yLVFrEXAgPqYoDG53Br/tCKiKYfX0MjVjQeWPIhPHHsCqzwQANq+FLN786fF5rgLS+gw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
-			"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
-			"integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
+			"integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.5",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
-			"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
+			"integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.5",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-simple-access": "^7.7.4",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-simple-access": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.7.4.tgz",
-			"integrity": "sha512-y2c96hmcsUi6LrMqvmNDPBBiGCiQu0aYqpHatVVu6kD4mFEXKjyNxd/drc18XXAf9dv7UXjrZwBVmTTGaGP8iw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
+			"integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-hoist-variables": "^7.8.3",
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-umd": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.7.4.tgz",
-			"integrity": "sha512-u2B8TIi0qZI4j8q4C51ktfO7E3cQ0qnaXFI1/OXITordD40tt17g/sXqgNNCcMTcBFKrUPcGDx+TBJuZxLx7tw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
+			"integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-module-transforms": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.7.4.tgz",
-			"integrity": "sha512-jBUkiqLKvUWpv9GLSuHUFYdmHg0ujC1JEYoZUfeOOfNydZXp1sXObgyPatpcwjWgsdBGsagWW0cdJpX/DO2jMw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.7.4.tgz",
-			"integrity": "sha512-CnPRiNtOG1vRodnsyGX37bHQleHE14B9dnnlgSeEs3ek3fHN1A1SScglTCg1sfbe7sRQ2BUcpgpTpWSfMKz3gg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
-			"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.7.7.tgz",
-			"integrity": "sha512-OhGSrf9ZBrr1fw84oFXj5hgi8Nmg+E2w5L7NhnG0lPvpDtqd7dbyilM2/vR8CKbJ907RyxPh2kj6sBCSSfI9Ew==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.4.tgz",
+			"integrity": "sha512-IsS3oTxeTsZlE5KqzTbcC2sV0P9pXdec53SU+Yxv7o/6dvGM5AkTotQKhoSffhNgZ/dftsSiOoxy7evCYJXzVA==",
 			"requires": {
-				"@babel/helper-call-delegate": "^7.7.4",
-				"@babel/helper-get-function-arity": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-call-delegate": "^7.8.3",
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
-			"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-react-display-name": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.7.4.tgz",
-			"integrity": "sha512-sBbIvqYkthai0X0vkD2xsAwluBp+LtNHH+/V4a5ydifmTtb8KOVOlrMIk/MYmIc4uTYDnjZUHQildYNo36SRJw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
+			"integrity": "sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.7.tgz",
-			"integrity": "sha512-SlPjWPbva2+7/ZJbGcoqjl4LsQaLpKEzxW9hcxU7675s24JmdotJOSJ4cgAbV82W3FcZpHIGmRZIlUL8ayMvjw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.8.3.tgz",
+			"integrity": "sha512-r0h+mUiyL595ikykci+fbwm9YzmuOrUBi0b+FDIKmi3fPQyFokWVEMJnRWHJPPQEjyFJyna9WZC6Viv6UHSv1g==",
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.7.4"
+				"@babel/helper-builder-react-jsx": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-self": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.7.4.tgz",
-			"integrity": "sha512-PWYjSfqrO273mc1pKCRTIJXyqfc9vWYBax88yIhQb+bpw3XChVC7VWS4VwRVs63wFHKxizvGSd00XEr+YB9Q2A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.8.3.tgz",
+			"integrity": "sha512-01OT7s5oa0XTLf2I8XGsL8+KqV9lx3EZV+jxn/L2LQ97CGKila2YMroTkCEIE0HV/FF7CMSRsIAybopdN9NTdg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-react-jsx-source": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.7.4.tgz",
-			"integrity": "sha512-5ZU9FnPhqtHsOXxutRtXZAzoEJwDaP32QcobbMP1/qt7NYcsCNK8XgzJcJfoEr/ZnzVvUNInNjIW22Z6I8p9mg==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.8.3.tgz",
+			"integrity": "sha512-PLMgdMGuVDtRS/SzjNEQYUT8f4z1xb2BAT54vM1X5efkVuYBf5WyGUMbpmARcfq3NaglIwz08UVQK4HHHbC6ag==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-jsx": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.7.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
-			"integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.3.tgz",
+			"integrity": "sha512-qt/kcur/FxrQrzFR432FGZznkVAjiyFtCOANjkAKwCbt465L6ZCiUQh2oMYGU3Wo8LRFJxNDFwWn106S5wVUNA==",
 			"requires": {
 				"regenerator-transform": "^0.14.0"
 			}
 		},
 		"@babel/plugin-transform-reserved-words": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.7.4.tgz",
-			"integrity": "sha512-OrPiUB5s5XvkCO1lS7D8ZtHcswIC57j62acAnJZKqGGnHP+TIc/ljQSrgdX/QyOTdEK5COAhuc820Hi1q2UgLQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.7.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
-			"integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
+			"integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.7.4.tgz",
-			"integrity": "sha512-q+suddWRfIcnyG5YiDP58sT65AJDZSUhXQDZE3r04AuqD6d/XLaQPPXSBzP2zGerkgBivqtQm9XKGLuHqBID6Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.7.4.tgz",
-			"integrity": "sha512-8OSs0FLe5/80cndziPlg4R0K6HcWSM0zyNhHhLsmw/Nc5MaA49cAsnoJ/t/YZf8qkG7fD+UjTRaApVDB526d7Q==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.7.4.tgz",
-			"integrity": "sha512-Ls2NASyL6qtVe1H1hXts9yuEeONV2TJZmplLONkMPUG158CtmnrzW5Q5teibM5UVOFjG0D3IC5mzXR6pPpUY7A==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-regex": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.7.4.tgz",
-			"integrity": "sha512-sA+KxLwF3QwGj5abMHkHgshp9+rRz+oY9uoRil4CyLtgEuE/88dpkeWgNk5qKVsJE9iSfly3nvHapdRiIS2wnQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.7.4.tgz",
-			"integrity": "sha512-KQPUQ/7mqe2m0B8VecdyaW5XcQYaePyl9R7IsKd+irzj6jvbhoGnRE+M0aNkyAzI07VfUQ9266L5xMARitV3wg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.7.4.tgz",
-			"integrity": "sha512-N77UUIV+WCvE+5yHw+oks3m18/umd7y392Zv7mYTpFqHtkpcc+QUz+gLJNTWVlWROIWeLqY0f3OjZxV5TcXnRw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
 			"requires": {
-				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0"
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
 		"@babel/polyfill": {
-			"version": "7.7.0",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
-			"integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.3.tgz",
+			"integrity": "sha512-0QEgn2zkCzqGIkSWWAEmvxD7e00Nm9asTtQvi7HdlYvMhjy/J38V/1Y9ode0zEJeIuxAI0uftiAzqc7nVeWUGg==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.7.tgz",
-			"integrity": "sha512-pCu0hrSSDVI7kCVUOdcMNQEbOPJ52E+LrQ14sN8uL2ALfSqePZQlKrOy+tM4uhEdYlCHi4imr8Zz2cZe9oSdIg==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+			"integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.7.4",
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
-				"@babel/plugin-proposal-dynamic-import": "^7.7.4",
-				"@babel/plugin-proposal-json-strings": "^7.7.4",
-				"@babel/plugin-proposal-object-rest-spread": "^7.7.7",
-				"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.7.7",
-				"@babel/plugin-syntax-async-generators": "^7.7.4",
-				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
-				"@babel/plugin-syntax-json-strings": "^7.7.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
-				"@babel/plugin-syntax-top-level-await": "^7.7.4",
-				"@babel/plugin-transform-arrow-functions": "^7.7.4",
-				"@babel/plugin-transform-async-to-generator": "^7.7.4",
-				"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
-				"@babel/plugin-transform-block-scoping": "^7.7.4",
-				"@babel/plugin-transform-classes": "^7.7.4",
-				"@babel/plugin-transform-computed-properties": "^7.7.4",
-				"@babel/plugin-transform-destructuring": "^7.7.4",
-				"@babel/plugin-transform-dotall-regex": "^7.7.7",
-				"@babel/plugin-transform-duplicate-keys": "^7.7.4",
-				"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
-				"@babel/plugin-transform-for-of": "^7.7.4",
-				"@babel/plugin-transform-function-name": "^7.7.4",
-				"@babel/plugin-transform-literals": "^7.7.4",
-				"@babel/plugin-transform-member-expression-literals": "^7.7.4",
-				"@babel/plugin-transform-modules-amd": "^7.7.5",
-				"@babel/plugin-transform-modules-commonjs": "^7.7.5",
-				"@babel/plugin-transform-modules-systemjs": "^7.7.4",
-				"@babel/plugin-transform-modules-umd": "^7.7.4",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
-				"@babel/plugin-transform-new-target": "^7.7.4",
-				"@babel/plugin-transform-object-super": "^7.7.4",
-				"@babel/plugin-transform-parameters": "^7.7.7",
-				"@babel/plugin-transform-property-literals": "^7.7.4",
-				"@babel/plugin-transform-regenerator": "^7.7.5",
-				"@babel/plugin-transform-reserved-words": "^7.7.4",
-				"@babel/plugin-transform-shorthand-properties": "^7.7.4",
-				"@babel/plugin-transform-spread": "^7.7.4",
-				"@babel/plugin-transform-sticky-regex": "^7.7.4",
-				"@babel/plugin-transform-template-literals": "^7.7.4",
-				"@babel/plugin-transform-typeof-symbol": "^7.7.4",
-				"@babel/plugin-transform-unicode-regex": "^7.7.4",
-				"@babel/types": "^7.7.4",
-				"browserslist": "^4.6.0",
-				"core-js-compat": "^3.6.0",
+				"@babel/compat-data": "^7.8.4",
+				"@babel/helper-compilation-targets": "^7.8.4",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
+				"@babel/plugin-proposal-json-strings": "^7.8.3",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-proposal-optional-chaining": "^7.8.3",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3",
+				"@babel/plugin-transform-arrow-functions": "^7.8.3",
+				"@babel/plugin-transform-async-to-generator": "^7.8.3",
+				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+				"@babel/plugin-transform-block-scoping": "^7.8.3",
+				"@babel/plugin-transform-classes": "^7.8.3",
+				"@babel/plugin-transform-computed-properties": "^7.8.3",
+				"@babel/plugin-transform-destructuring": "^7.8.3",
+				"@babel/plugin-transform-dotall-regex": "^7.8.3",
+				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
+				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+				"@babel/plugin-transform-for-of": "^7.8.4",
+				"@babel/plugin-transform-function-name": "^7.8.3",
+				"@babel/plugin-transform-literals": "^7.8.3",
+				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
+				"@babel/plugin-transform-modules-amd": "^7.8.3",
+				"@babel/plugin-transform-modules-commonjs": "^7.8.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.8.3",
+				"@babel/plugin-transform-modules-umd": "^7.8.3",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+				"@babel/plugin-transform-new-target": "^7.8.3",
+				"@babel/plugin-transform-object-super": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.8.4",
+				"@babel/plugin-transform-property-literals": "^7.8.3",
+				"@babel/plugin-transform-regenerator": "^7.8.3",
+				"@babel/plugin-transform-reserved-words": "^7.8.3",
+				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
+				"@babel/plugin-transform-spread": "^7.8.3",
+				"@babel/plugin-transform-sticky-regex": "^7.8.3",
+				"@babel/plugin-transform-template-literals": "^7.8.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
+				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/types": "^7.8.3",
+				"browserslist": "^4.8.5",
+				"core-js-compat": "^3.6.2",
 				"invariant": "^2.2.2",
-				"js-levenshtein": "^1.1.3",
+				"levenary": "^1.1.1",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				}
 			}
 		},
 		"@babel/preset-react": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.7.4.tgz",
-			"integrity": "sha512-j+vZtg0/8pQr1H8wKoaJyGL2IEk3rG/GIvua7Sec7meXVIvGycihlGMx5xcU00kqCJbwzHs18xTu3YfREOqQ+g==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.8.3.tgz",
+			"integrity": "sha512-9hx0CwZg92jGb7iHYQVgi0tOEHP/kM60CtWJQnmbATSPIQQ2xYzfoCI3EdqAhFBeeJwYMdWQuDUHMsuDbH9hyQ==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-react-display-name": "^7.7.4",
-				"@babel/plugin-transform-react-jsx": "^7.7.4",
-				"@babel/plugin-transform-react-jsx-self": "^7.7.4",
-				"@babel/plugin-transform-react-jsx-source": "^7.7.4"
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-transform-react-display-name": "^7.8.3",
+				"@babel/plugin-transform-react-jsx": "^7.8.3",
+				"@babel/plugin-transform-react-jsx-self": "^7.8.3",
+				"@babel/plugin-transform-react-jsx-source": "^7.8.3"
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
-			"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
+			"integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.7.7",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.7.tgz",
-			"integrity": "sha512-kr3W3Fw8mB/CTru2M5zIRQZZgC/9zOxNSoJ/tVCzjPt3H1/p5uuGbz6WwmaQy/TLQcW31rUhUUWKY28sXFRelA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
+			"integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-			"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+			"integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.7.4",
-				"@babel/types": "^7.7.4"
+				"@babel/code-frame": "^7.8.3",
+				"@babel/parser": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-			"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+			"integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
 			"requires": {
-				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.7.4",
-				"@babel/helper-function-name": "^7.7.4",
-				"@babel/helper-split-export-declaration": "^7.7.4",
-				"@babel/parser": "^7.7.4",
-				"@babel/types": "^7.7.4",
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.8.4",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/parser": "^7.8.4",
+				"@babel/types": "^7.8.3",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-			"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+			"integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -1784,9 +1838,9 @@
 			}
 		},
 		"@mikaelkristiansson/domready": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/@mikaelkristiansson/domready/-/domready-1.0.9.tgz",
-			"integrity": "sha512-FOAjeRHULSWXd6JMuCDwf3zPbe11kP971+Bufrj9M8rQ33ZMtThgKd6IJgzj6tr/+1Rq3czzLI1LAa9x0IC92w=="
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@mikaelkristiansson/domready/-/domready-1.0.10.tgz",
+			"integrity": "sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg=="
 		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
@@ -2020,9 +2074,9 @@
 			}
 		},
 		"@types/history": {
-			"version": "4.7.3",
-			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.3.tgz",
-			"integrity": "sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw=="
+			"version": "4.7.4",
+			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.4.tgz",
+			"integrity": "sha512-+o2igcuZA3xtOoFH56s+MCZVidwlJNcJID57DSCyawS2i910yG9vkwehCjJNZ6ImhCR5S9DbvIJKyYHcMyOfMw=="
 		},
 		"@types/istanbul-lib-coverage": {
 			"version": "2.0.1",
@@ -2030,9 +2084,9 @@
 			"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
 		},
 		"@types/istanbul-lib-report": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-			"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
 			"requires": {
 				"@types/istanbul-lib-coverage": "*"
 			}
@@ -2050,6 +2104,11 @@
 			"version": "24.0.0",
 			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.0.tgz",
 			"integrity": "sha512-kOafJnUTnMd7/OfEO/x3I47EHswNjn+dbz9qk3mtonr1RvKT+1FGVxnxAx08I9K8Tl7j9hpoJRE7OCf+t10fng=="
+		},
+		"@types/js-cookie": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.4.tgz",
+			"integrity": "sha512-WTfSE1Eauak/Nrg6cA9FgPTFvVawejsai6zXoq0QYTQ3mxONeRtGhKxa7wMlUzWWmzrmTeV+rwLjHgsCntdrsA=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.4",
@@ -2069,6 +2128,11 @@
 				"@types/unist": "*"
 			}
 		},
+		"@types/mime-types": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+			"integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2080,9 +2144,9 @@
 			"integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
 		},
 		"@types/node": {
-			"version": "13.1.2",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
-			"integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ=="
+			"version": "13.5.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
+			"integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -2115,9 +2179,9 @@
 			}
 		},
 		"@types/react": {
-			"version": "16.9.17",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.17.tgz",
-			"integrity": "sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==",
+			"version": "16.9.19",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.19.tgz",
+			"integrity": "sha512-LJV97//H+zqKWMms0kvxaKYJDG05U2TtQB3chRLF8MPNs+MQh/H1aGlyDUxjaHvu08EAGerdX2z4LTBc7ns77A==",
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -2194,24 +2258,24 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "13.0.4",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
-			"integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
+			"version": "13.0.7",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.7.tgz",
+			"integrity": "sha512-Sg9kNeJz+V+W+0fugcVhHC+mNHnydDR1RJrW5Qn2jVrDQARF8wfPVqIqwEzZp+bneuEBIm2ClsJ1/je42ZBzSg==",
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
-			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.14.0.tgz",
-			"integrity": "sha512-sneOJ3Hu0m5whJiVIxGBZZZMxMJ7c0LhAJzeMJgHo+n5wFs+/6rSR/gl7crkdR2kNwfOOSdzdc0gMvatG4dX2Q==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.18.0.tgz",
+			"integrity": "sha512-kuO8WQjV+RCZvAXVRJfXWiJ8iYEtfHlKgcqqqXg9uUkIolEHuUaMmm8/lcO4xwCOtaw6mY0gStn2Lg4/eUXXYQ==",
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.14.0",
+				"@typescript-eslint/experimental-utils": "2.18.0",
 				"eslint-utils": "^1.4.3",
 				"functional-red-black-tree": "^1.0.1",
 				"regexpp": "^3.0.0",
@@ -2219,36 +2283,36 @@
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.14.0.tgz",
-			"integrity": "sha512-KcyKS7G6IWnIgl3ZpyxyBCxhkBPV+0a5Jjy2g5HxlrbG2ZLQNFeneIBVXdaBCYOVjvGmGGFKom1kgiAY75SDeQ==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.18.0.tgz",
+			"integrity": "sha512-J6MopKPHuJYmQUkANLip7g9I82ZLe1naCbxZZW3O2sIxTiq/9YYoOELEKY7oPg0hJ0V/AQ225h2z0Yp+RRMXhw==",
 			"requires": {
 				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.14.0",
+				"@typescript-eslint/typescript-estree": "2.18.0",
 				"eslint-scope": "^5.0.0"
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.14.0.tgz",
-			"integrity": "sha512-haS+8D35fUydIs+zdSf4BxpOartb/DjrZ2IxQ5sR8zyGfd77uT9ZJZYF8+I0WPhzqHmfafUBx8MYpcp8pfaoSA==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.18.0.tgz",
+			"integrity": "sha512-SJJPxFMEYEWkM6pGfcnjLU+NJIPo+Ko1QrCBL+i0+zV30ggLD90huEmMMhKLHBpESWy9lVEeWlQibweNQzyc+A==",
 			"requires": {
 				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.14.0",
-				"@typescript-eslint/typescript-estree": "2.14.0",
+				"@typescript-eslint/experimental-utils": "2.18.0",
+				"@typescript-eslint/typescript-estree": "2.18.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "2.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.14.0.tgz",
-			"integrity": "sha512-pnLpUcMNG7GfFFfNQbEX6f1aPa5fMnH2G9By+A1yovYI4VIOK2DzkaRuUlIkbagpAcrxQHLqovI1YWqEcXyRnA==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.18.0.tgz",
+			"integrity": "sha512-gVHylf7FDb8VSi2ypFuEL3hOtoC4HkZZ5dOjXvVjoyKdRrvXAOPSzpNRnKMfaUUEiSLP8UF9j9X9EDLxC0lfZg==",
 			"requires": {
 				"debug": "^4.1.1",
 				"eslint-visitor-keys": "^1.1.0",
 				"glob": "^7.1.6",
 				"is-glob": "^4.0.1",
-				"lodash.unescape": "4.0.1",
+				"lodash": "^4.17.15",
 				"semver": "^6.3.0",
 				"tsutils": "^3.17.1"
 			},
@@ -2419,9 +2483,9 @@
 			}
 		},
 		"@xobotyi/scrollbar-width": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.5.0.tgz",
-			"integrity": "sha512-BK+HR1D00F2xh7n4+5en8/dMkG13uvIXLmEbsjtc1702b7+VwXkvlBDKoRPJMbkRN5hD7VqWa3nS9fNT8JG3CA=="
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.8.2.tgz",
+			"integrity": "sha512-RV6+4hR29oMaPCvSYFUvzOvlsrg2s2k5NE9tNERs+4nFIC9dRXxs+lL2CcaRTbl3yQxKwAZ8Cd+qMI8aUu9TFw=="
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -2484,7 +2548,7 @@
 			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
 		},
 		"act-rules-community": {
-			"version": "github:act-rules/act-rules.github.io#fc6b806857cae7d29e543e6ed7f1b66b5051630b",
+			"version": "github:act-rules/act-rules.github.io#89ad7e24b7126ad2f77630fd7eca3b3c346e5e39",
 			"from": "github:act-rules/act-rules.github.io#develop",
 			"requires": {
 				"fastmatter": "^2.1.1",
@@ -2500,7 +2564,7 @@
 			}
 		},
 		"act-rules-implementation-access-board": {
-			"version": "github:act-rules/act-rules-implementation-access-board#fb786d074506fea653e3e2f53e2bbbab18a18698",
+			"version": "github:act-rules/act-rules-implementation-access-board#18654831fdf4e6325de72364c81206f899d4fbbe",
 			"from": "github:act-rules/act-rules-implementation-access-board"
 		},
 		"act-rules-implementation-access-engine": {
@@ -2508,18 +2572,18 @@
 			"from": "github:act-rules/act-rules-implementation-access-engine"
 		},
 		"act-rules-implementation-alfa": {
-			"version": "github:act-rules/act-rules-implementation-alfa#29ffe3a3522ede09d06b56abfe63e42e5f88e405",
+			"version": "github:act-rules/act-rules-implementation-alfa#4917a3d252125c7859ea541d2840fd30239bcb88",
 			"from": "github:act-rules/act-rules-implementation-alfa"
 		},
 		"act-rules-implementation-axe-core": {
-			"version": "github:act-rules/act-rules-implementation-axe-core#9757615e81646d058a85c55f46e74031e3a7b47d",
+			"version": "github:act-rules/act-rules-implementation-axe-core#2da08bb92267bfc00387d8d8f105d2920902c8ec",
 			"from": "github:act-rules/act-rules-implementation-axe-core",
 			"requires": {
 				"assert": "^2.0.0",
 				"axe-core": "github:dequelabs/axe-core#wai-tools",
 				"axe-puppeteer": "^1.0.0",
 				"commander": "^2.20.0",
-				"puppeteer": "^2.0.0",
+				"puppeteer": "^2.1.0",
 				"static-server": "^2.2.1"
 			},
 			"dependencies": {
@@ -2531,7 +2595,7 @@
 			}
 		},
 		"act-rules-implementation-mapper": {
-			"version": "github:act-rules/act-rules-implementation-mapper#10f38d0d38c6927e32af5f82a17594af111a488f",
+			"version": "github:act-rules/act-rules-implementation-mapper#3b4230ced6e23dae4fc051ef24ce140f97aa1da7",
 			"from": "github:act-rules/act-rules-implementation-mapper",
 			"requires": {
 				"@types/debug": "^4.1.5",
@@ -2550,15 +2614,15 @@
 			}
 		},
 		"act-rules-implementation-qualweb": {
-			"version": "github:act-rules/act-rules-implementation-qualweb#7251a62783b91f3837e18734978de88663092ebf",
+			"version": "github:act-rules/act-rules-implementation-qualweb#01e3dee3b10645825137fd5830d7c3479e5afe84",
 			"from": "github:act-rules/act-rules-implementation-qualweb"
 		},
 		"act-rules-implementation-rgaa": {
-			"version": "github:act-rules/act-rules-implementation-rgaa#faf70d423da36a2e013f9d0c1a041337ad0539d2",
+			"version": "github:act-rules/act-rules-implementation-rgaa#a01d13f6fe3ba673e776317caf49c723ea6c45d6",
 			"from": "github:act-rules/act-rules-implementation-rgaa"
 		},
 		"act-rules-implementation-trusted-tester": {
-			"version": "github:act-rules/act-rules-implementation-trusted-tester#fb786d074506fea653e3e2f53e2bbbab18a18698",
+			"version": "github:act-rules/act-rules-implementation-trusted-tester#18654831fdf4e6325de72364c81206f899d4fbbe",
 			"from": "github:act-rules/act-rules-implementation-trusted-tester"
 		},
 		"address": {
@@ -2572,12 +2636,9 @@
 			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
 		},
 		"agent-base": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-			"requires": {
-				"es6-promisify": "^5.0.0"
-			}
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
 		},
 		"aggregate-error": {
 			"version": "3.0.1",
@@ -2589,11 +2650,11 @@
 			}
 		},
 		"ajv": {
-			"version": "6.10.2",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+			"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
+				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
@@ -2819,9 +2880,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -2917,9 +2978,9 @@
 			}
 		},
 		"array-iterate": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.3.tgz",
-			"integrity": "sha512-7MIv7HE9MuzfK6B2UnWv07oSHBLOaY1UUXAxZ07bIeRM+4IkPTlveMDs9MY//qvxPZPSvCn2XV4bmtQgSkVodg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
+			"integrity": "sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA=="
 		},
 		"array-map": {
 			"version": "0.0.0",
@@ -3060,16 +3121,16 @@
 			"optional": true
 		},
 		"autoprefixer": {
-			"version": "9.7.3",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
-			"integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
+			"version": "9.7.4",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+			"integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
 			"requires": {
-				"browserslist": "^4.8.0",
-				"caniuse-lite": "^1.0.30001012",
+				"browserslist": "^4.8.3",
+				"caniuse-lite": "^1.0.30001020",
 				"chalk": "^2.4.2",
 				"normalize-range": "^0.1.2",
 				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.23",
+				"postcss": "^7.0.26",
 				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
@@ -3082,13 +3143,13 @@
 					}
 				},
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"chalk": {
@@ -3117,12 +3178,12 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-			"integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
 		},
 		"axe-core": {
-			"version": "github:dequelabs/axe-core#46d49df9f69f7fffa6632a1efcf4179900fe5d7d",
+			"version": "github:dequelabs/axe-core#61f91c93ca903919973abd118de8f3a51328c3c5",
 			"from": "github:dequelabs/axe-core#wai-tools"
 		},
 		"axe-puppeteer": {
@@ -3134,12 +3195,11 @@
 			}
 		},
 		"axios": {
-			"version": "0.19.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
 			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
+				"follow-redirects": "1.5.10"
 			}
 		},
 		"axobject-query": {
@@ -3462,9 +3522,9 @@
 			}
 		},
 		"babel-plugin-remove-graphql-queries": {
-			"version": "2.7.19",
-			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
-			"integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
+			"version": "2.7.22",
+			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.22.tgz",
+			"integrity": "sha512-gb4bKZvePZME/VRBMiIZfnli1BIO0K8cm1Pj9HPm85PqElPHzdjeUZ9p3ybOCGe+BBpIlqKx7mx9V/RsjlH+SA=="
 		},
 		"babel-plugin-transform-react-remove-prop-types": {
 			"version": "0.4.24",
@@ -3472,9 +3532,9 @@
 			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
 		"babel-preset-gatsby": {
-			"version": "0.2.26",
-			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
-			"integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
+			"version": "0.2.27",
+			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.27.tgz",
+			"integrity": "sha512-BXoUhKfBZUQb6nR5/fmQeNpKN137eucvRvKUGYcz9ZPbJOALSek03wseJA4zK8rV+mIQYM47y+AFs09RU/aOHg==",
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.7.4",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
@@ -3521,9 +3581,9 @@
 			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
 		},
 		"bail": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
-			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -4372,13 +4432,6 @@
 			"requires": {
 				"es6-promisify": "^6.0.0",
 				"lockfile": "^1.0.4"
-			},
-			"dependencies": {
-				"es6-promisify": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
-					"integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg=="
-				}
 			}
 		},
 		"cacheable-request": {
@@ -4486,21 +4539,21 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				}
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001017",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001017.tgz",
-			"integrity": "sha512-EDnZyOJ6eYh6lHmCvCdHAFbfV4KJ9lSdfv4h/ppEhrU/Yudkl7jujwMZ1we6RX7DXqBfT04pVMQ4J+1wcTlsKA=="
+			"version": "1.0.30001023",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+			"integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA=="
 		},
 		"canonicalize": {
 			"version": "1.0.1",
@@ -4532,9 +4585,9 @@
 			}
 		},
 		"ccount": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
-			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+			"integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw=="
 		},
 		"chalk": {
 			"version": "0.5.1",
@@ -4549,24 +4602,24 @@
 			}
 		},
 		"character-entities": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
 		},
 		"character-entities-html4": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
-			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+			"integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g=="
 		},
 		"character-entities-legacy": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
 		},
 		"character-reference-invalid": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
 		},
 		"chardet": {
 			"version": "0.7.0",
@@ -4740,9 +4793,9 @@
 			"integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
 		},
 		"clean-css": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
-			"integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+			"integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
 			"requires": {
 				"source-map": "~0.6.0"
 			}
@@ -5030,9 +5083,9 @@
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collapse-white-space": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
-			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -5088,9 +5141,9 @@
 			}
 		},
 		"comma-separated-tokens": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
-			"integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+			"integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
 		},
 		"command-exists": {
 			"version": "1.2.8",
@@ -5128,11 +5181,11 @@
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
 		},
 		"compressible": {
-			"version": "2.0.17",
-			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
-			"integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+			"integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
 			"requires": {
-				"mime-db": ">= 1.40.0 < 2"
+				"mime-db": ">= 1.43.0 < 2"
 			}
 		},
 		"compression": {
@@ -5191,9 +5244,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5366,9 +5419,9 @@
 			}
 		},
 		"copyfiles": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.1.1.tgz",
-			"integrity": "sha512-y6DZHve80whydXzBal7r70TBgKMPKesVRR1Sn/raUu7Jh/i7iSLSyGvYaq0eMJ/3Y/CKghwzjY32q1WzEnpp3Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.2.0.tgz",
+			"integrity": "sha512-iJbHJI+8OKqsq+4JF0rqgRkZzo++jqO6Wf4FUU1JM41cJF6JcY5968XyF4tm3Kkm7ZOMrqlljdm8N9oyY5raGw==",
 			"requires": {
 				"glob": "^7.0.5",
 				"minimatch": "^3.0.3",
@@ -5384,9 +5437,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -5444,22 +5497,22 @@
 			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 		},
 		"core-js-compat": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.1.tgz",
-			"integrity": "sha512-2Tl1EuxZo94QS2VeH28Ebf5g3xbPZG/hj/N5HDDy4XMP/ImR0JIer/nggQRiMN91Q54JVkGbytf42wO29oXVHg==",
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+			"integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
 			"requires": {
-				"browserslist": "^4.8.2",
+				"browserslist": "^4.8.3",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"semver": {
@@ -5470,9 +5523,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.1.tgz",
-			"integrity": "sha512-yKiUdvQWq66xUc408duxUCxFHuDfz5trF5V4xnQzb8C7P/5v2gFUdyNWQoevyAeGYB1hl1X/pzGZ20R3WxZQBA=="
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+			"integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -5940,9 +5993,9 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"damerau-levenshtein": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-			"integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA=="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+			"integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug=="
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -6078,9 +6131,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -6258,9 +6311,9 @@
 			}
 		},
 		"defer-to-connect": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
-			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -6323,9 +6376,9 @@
 			},
 			"dependencies": {
 				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+					"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -6368,9 +6421,9 @@
 			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
 		},
 		"detab": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/detab/-/detab-2.0.2.tgz",
-			"integrity": "sha512-Q57yPrxScy816TTE1P/uLRXLDKjXhvYTbfxS/e6lPD+YrqghbsMlGB9nQzj/zVtSPaF0DFPSdO916EWO4sQUyQ==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/detab/-/detab-2.0.3.tgz",
+			"integrity": "sha512-Up8P0clUVwq0FnFjDclzZsy9PadzRn5FFxrr47tQQvMHqyiFYVbpH8oXDzWtF0Q7pYy3l+RPmtBl+BsFF6wH0A==",
 			"requires": {
 				"repeat-string": "^1.5.4"
 			}
@@ -6681,9 +6734,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -6724,9 +6777,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.322",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-			"integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA=="
+			"version": "1.3.344",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.344.tgz",
+			"integrity": "sha512-tvbx2Wl8WBR+ym3u492D0L6/jH+8NoQXqe46+QhbWH3voVPauGuZYeb1QAXYoOAWuiP2dbSvlBx0kQ1F3hu/Mw=="
 		},
 		"elegant-spinner": {
 			"version": "1.0.1",
@@ -6874,9 +6927,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -6934,17 +6987,17 @@
 			}
 		},
 		"error-stack-parser": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.4.tgz",
-			"integrity": "sha512-fZ0KkoxSjLFmhW5lHbUT3tLwy3nX1qEzMYo8koY1vrsAco53CMT1djnBSeC/wUjTEZRhZl9iRw7PaMaxfJ4wzQ==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+			"integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
 			"requires": {
-				"stackframe": "^1.1.0"
+				"stackframe": "^1.1.1"
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-			"integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+			"version": "1.17.4",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -6974,18 +7027,10 @@
 			"resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
 			"integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
 		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-		},
 		"es6-promisify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-			"requires": {
-				"es6-promise": "^4.0.3"
-			}
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
+			"integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg=="
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -6998,22 +7043,15 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
+			"integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
 			"requires": {
-				"esprima": "^3.1.3",
+				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
 				"optionator": "^0.8.1",
 				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"esprima": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-				}
 			}
 		},
 		"eslint": {
@@ -7143,12 +7181,12 @@
 			}
 		},
 		"eslint-import-resolver-node": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
-			"integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+			"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
 			"requires": {
 				"debug": "^2.6.9",
-				"resolve": "^1.5.0"
+				"resolve": "^1.13.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -7179,9 +7217,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
-			"integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
 			"requires": {
 				"debug": "^2.6.9",
 				"pkg-dir": "^2.0.0"
@@ -7248,11 +7286,6 @@
 				}
 			}
 		},
-		"eslint-plugin-eslint-plugin": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz",
-			"integrity": "sha512-kT3A/ZJftt28gbl/Cv04qezb/NQ1dwYIbi8lyf806XMxkus7DvOVCLIfTXMrorp322Pnoez7+zabXH29tADIDg=="
-		},
 		"eslint-plugin-flowtype": {
 			"version": "3.13.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
@@ -7271,9 +7304,9 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.19.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
-			"integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.0.tgz",
+			"integrity": "sha512-NK42oA0mUc8Ngn4kONOPsPB1XhbUvNHqF+g307dPV28aknPoiNnKLFd9em4nkswwepdF5ouieqv5Th/63U7YJQ==",
 			"requires": {
 				"array-includes": "^3.0.3",
 				"array.prototype.flat": "^1.2.1",
@@ -7424,20 +7457,19 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.17.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz",
-			"integrity": "sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==",
+			"version": "7.18.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz",
+			"integrity": "sha512-p+PGoGeV4SaZRDsXqdj9OWcOrOpZn8gXoGPcIQTzo2IDMbAKhNDnME9myZWqO3Ic4R3YmwAZ1lDjWl2R2hMUVQ==",
 			"requires": {
-				"array-includes": "^3.0.3",
+				"array-includes": "^3.1.1",
 				"doctrine": "^2.1.0",
-				"eslint-plugin-eslint-plugin": "^2.1.0",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.2.3",
-				"object.entries": "^1.1.0",
-				"object.fromentries": "^2.0.1",
-				"object.values": "^1.1.0",
+				"object.entries": "^1.1.1",
+				"object.fromentries": "^2.0.2",
+				"object.values": "^1.1.1",
 				"prop-types": "^15.7.2",
-				"resolve": "^1.13.1"
+				"resolve": "^1.14.2"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -7531,9 +7563,9 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"event-source-polyfill": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.11.tgz",
-			"integrity": "sha512-fbo96OutP0Bb+gIYTTy8LGhNWySdetsFElCn/vhOzQL3cXWsS70TP/aRUe32U7F+PuOZH/tvb40tZgoJV8/Ilw=="
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.12.tgz",
+			"integrity": "sha512-WjOTn0LIbaN08z/8gNt3GYAomAdm6cZ2lr/QdvhTTEipr5KR6lds2ziUH+p/Iob4Lk6NClKhwPOmn1NjQEcJCg=="
 		},
 		"eventemitter3": {
 			"version": "4.0.0",
@@ -7541,9 +7573,9 @@
 			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
 		},
 		"events": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-			"integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+			"integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
 		},
 		"eventsource": {
 			"version": "0.1.6",
@@ -7994,9 +8026,9 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
 		},
 		"fast-glob": {
 			"version": "3.1.1",
@@ -8021,9 +8053,9 @@
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fast-shallow-equal": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-0.1.1.tgz",
-			"integrity": "sha512-XVP6nhaXLYOH6JZCWBcNaeEer9GJ5/8cJWUP+OLmgwWgEkJp5Kpl/fdpJ01zl0mpLxrk7f5J3hIv+GmjTCi7Mg=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+			"integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
 		},
 		"fastest-stable-stringify": {
 			"version": "1.0.1",
@@ -8052,6 +8084,14 @@
 			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
 			"requires": {
 				"reusify": "^1.0.0"
+			}
+		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -8292,9 +8332,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -8363,6 +8403,11 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+		},
 		"forwarded": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -8396,9 +8441,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -8445,9 +8490,9 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.0.0.tgz",
-			"integrity": "sha512-40Qz+LFXmd9tzYVnnBmZvFfvAADfUA14TXPK1s7IfElJTIZ97rA8w4Kin7Wt5JBrC3ShnnFJO/5vPjPEeJIq9A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
 			"requires": {
 				"minipass": "^3.0.0"
 			}
@@ -8469,9 +8514,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -9014,14 +9059,14 @@
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
 		"fuzzy-search": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/fuzzy-search/-/fuzzy-search-3.0.2.tgz",
-			"integrity": "sha512-u3moKS69EAq12J+EPjAeF64u4gir6OzX/gDUNu4FXW2/5UfqqxvuYLWDEf7ehaz/TIMuYYh98HlJ2caUbpAiww=="
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fuzzy-search/-/fuzzy-search-3.1.0.tgz",
+			"integrity": "sha512-LZXJmVbDjEdBmVDh4UBDN0GivaJ56xmyiCXPNxZ6aNPzxlGK7GZRIVo60SkIC9lWTxxvjHNHkX0Q+RzNwt9j+w=="
 		},
 		"gatsby": {
-			"version": "2.18.17",
-			"resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.18.17.tgz",
-			"integrity": "sha512-Zj/LjZwzM0RXoqMmM+6H48IOazmJcuzyVY2yfTi8oYtcQH0F4xIELiDZJkZQb7mttlIsJTX3U1NLCYXPcohWwg==",
+			"version": "2.19.10",
+			"resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.19.10.tgz",
+			"integrity": "sha512-Jl7SigQegrXq3cQQzGbY7b7jz7buLpqDPkPe10Ehkbkl8Z/aGN8OXnM5xSi+DZJ2dpHUOzm4pLr30diNPXC1rw==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"@babel/core": "^7.7.5",
@@ -9030,7 +9075,7 @@
 				"@babel/runtime": "^7.7.6",
 				"@babel/traverse": "^7.7.4",
 				"@hapi/joi": "^15.1.1",
-				"@mikaelkristiansson/domready": "^1.0.9",
+				"@mikaelkristiansson/domready": "^1.0.10",
 				"@pieh/friendly-errors-webpack-plugin": "1.7.0-chalk-2",
 				"@reach/router": "^1.2.1",
 				"@typescript-eslint/eslint-plugin": "^2.11.0",
@@ -9043,8 +9088,8 @@
 				"babel-loader": "^8.0.6",
 				"babel-plugin-add-module-exports": "^0.3.3",
 				"babel-plugin-dynamic-import-node": "^2.3.0",
-				"babel-plugin-remove-graphql-queries": "^2.7.19",
-				"babel-preset-gatsby": "^0.2.26",
+				"babel-plugin-remove-graphql-queries": "^2.7.22",
+				"babel-preset-gatsby": "^0.2.27",
 				"better-opn": "1.0.0",
 				"better-queue": "^3.8.10",
 				"bluebird": "^3.7.2",
@@ -9082,18 +9127,19 @@
 				"flat": "^4.1.0",
 				"fs-exists-cached": "1.0.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-cli": "^2.8.22",
-				"gatsby-core-utils": "^1.0.25",
-				"gatsby-graphiql-explorer": "^0.2.31",
-				"gatsby-link": "^2.2.27",
-				"gatsby-plugin-page-creator": "^2.1.37",
-				"gatsby-react-router-scroll": "^2.1.19",
-				"gatsby-telemetry": "^1.1.46",
+				"gatsby-cli": "^2.8.28",
+				"gatsby-core-utils": "^1.0.27",
+				"gatsby-graphiql-explorer": "^0.2.32",
+				"gatsby-link": "^2.2.28",
+				"gatsby-plugin-page-creator": "^2.1.39",
+				"gatsby-react-router-scroll": "^2.1.20",
+				"gatsby-telemetry": "^1.1.48",
 				"glob": "^7.1.6",
 				"got": "8.3.2",
 				"graphql": "^14.5.8",
 				"graphql-compose": "^6.3.7",
 				"graphql-playground-middleware-express": "^1.7.12",
+				"hasha": "^5.1.0",
 				"invariant": "^2.2.4",
 				"is-relative": "^1.0.0",
 				"is-relative-url": "^3.0.0",
@@ -9116,6 +9162,7 @@
 				"null-loader": "^0.1.1",
 				"opentracing": "^0.14.4",
 				"optimize-css-assets-webpack-plugin": "^5.0.3",
+				"p-defer": "^3.0.0",
 				"parseurl": "^1.3.3",
 				"physical-cpu-count": "^2.0.0",
 				"pnp-webpack-plugin": "^1.5.0",
@@ -9313,9 +9360,9 @@
 					}
 				},
 				"gatsby-cli": {
-					"version": "2.8.22",
-					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.22.tgz",
-					"integrity": "sha512-uZix0CalIzZ6Wx5pbu5VoWA7KalWdWdfofm+thXRe4VlyJ9VnKmHAslBB03NOl707JoMsBLshHsGYynHwp0jdA==",
+					"version": "2.8.28",
+					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.28.tgz",
+					"integrity": "sha512-Kqeoq6HQe++SrJ6Fa93rzHCo7LAOMNQfLLMr88mmdqRSXnualtMUseY0nY9oPzToQchwRARDN9pn2sGw6qUS4g==",
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
 						"@babel/runtime": "^7.7.6",
@@ -9332,8 +9379,8 @@
 						"execa": "^3.4.0",
 						"fs-exists-cached": "^1.0.0",
 						"fs-extra": "^8.1.0",
-						"gatsby-core-utils": "^1.0.25",
-						"gatsby-telemetry": "^1.1.46",
+						"gatsby-core-utils": "^1.0.27",
+						"gatsby-telemetry": "^1.1.48",
 						"hosted-git-info": "^3.0.2",
 						"ink": "^2.6.0",
 						"ink-spinner": "^3.0.1",
@@ -9364,6 +9411,11 @@
 							"version": "6.3.0",
 							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+						},
+						"uuid": {
+							"version": "3.3.3",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+							"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 						}
 					}
 				},
@@ -9659,26 +9711,26 @@
 			}
 		},
 		"gatsby-core-utils": {
-			"version": "1.0.25",
-			"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.25.tgz",
-			"integrity": "sha512-Pz5xueweH9qv5TIW7wwlTxI/CbyzkiE5xvgLicbHbU+InH+lCNt4VuvGP1gQcIRuHMCIbuVKSiVCC7jnxEbtrA==",
+			"version": "1.0.27",
+			"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.27.tgz",
+			"integrity": "sha512-w75Sjby/XhYQexeDTAQoBI385BXMt79B+hT55JwQmtz1VJ4/gQMUENG2J5ABzPsN7rD1TueNcR9BpU5Ns7sgdw==",
 			"requires": {
 				"ci-info": "2.0.0",
 				"node-object-hash": "^2.0.0"
 			}
 		},
 		"gatsby-graphiql-explorer": {
-			"version": "0.2.31",
-			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
-			"integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
+			"version": "0.2.32",
+			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.32.tgz",
+			"integrity": "sha512-0Fzx5JOevUBtD8s94q3Pfjp0LPSVHWNijGXBfRRdcpzKPJZuvYAzVkRz5aQgx1FPavSJE8q9uC+Uo4VzyyPpJg==",
 			"requires": {
 				"@babel/runtime": "^7.7.6"
 			}
 		},
 		"gatsby-link": {
-			"version": "2.2.27",
-			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
-			"integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
+			"version": "2.2.28",
+			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.28.tgz",
+			"integrity": "sha512-G1ivEChE2eNxrPoKXR3Z27bZUWBNcL+SybJ+V0+xnR2y/w/hLe7DTOCt/UTCKgtvJ0jvQodwK7r1+HroXmsnVw==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"@types/reach__router": "^1.2.6",
@@ -9686,15 +9738,15 @@
 			}
 		},
 		"gatsby-page-utils": {
-			"version": "0.0.36",
-			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.36.tgz",
-			"integrity": "sha512-W+9+PdEWKCxO5cEr8D3F0vyN2sDLeoSwROwiuO+J791HHUj+HgnDzRAt97WjBwcD4ghT+ONs5Ao2WyR+bVrIzw==",
+			"version": "0.0.38",
+			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.38.tgz",
+			"integrity": "sha512-tM+ByO2BPRdgGkUWkqFbLz4q9Xy896xjdkDkR6weJdqAS5K8nux56UikeYG1WJJ0AUut0R8zlGukb0QUdm80Qw==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"bluebird": "^3.7.2",
 				"chokidar": "3.3.0",
 				"fs-exists-cached": "^1.0.0",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
 				"micromatch": "^3.1.10"
@@ -9803,25 +9855,25 @@
 			}
 		},
 		"gatsby-plugin-manifest": {
-			"version": "2.2.34",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.34.tgz",
-			"integrity": "sha512-Jo6fXZpJ/QSejrSj9BTfRNikVDjx9FuuKzT4w7il8I6qKtnM4z/lYOIMxRWkAdlK7dj+fpUlbTeClWjhlKRWAQ==",
+			"version": "2.2.40",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.40.tgz",
+			"integrity": "sha512-HulJATqu5pp1FX5e3fcg5/NMwek7v0VUqYaqtW164MTG0/knTRNhH0YJX/bvQgi3CDDW5bFX6bpKCQ5sbRo9DQ==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"semver": "^5.7.1",
 				"sharp": "^0.23.4"
 			}
 		},
 		"gatsby-plugin-page-creator": {
-			"version": "2.1.37",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.37.tgz",
-			"integrity": "sha512-EsHDgT4hQx9Zxqf6zUIP9qQh+0Wk1tPyiJtPRADY1jkzwu2dAidJkaUtH4XR8BExhjZ9xYB5uDliSNrGkZg7fw==",
+			"version": "2.1.39",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.39.tgz",
+			"integrity": "sha512-tojv5cnt8pm5Cvks06Rypy8Ha/nONIIx+uEA1+iCsE2ekRm5ziiV5VqVSLrAxWwV2w0OgKDov+lMCco2xkdY4Q==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"bluebird": "^3.7.2",
 				"fs-exists-cached": "^1.0.0",
-				"gatsby-page-utils": "^0.0.36",
+				"gatsby-page-utils": "^0.0.38",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
 				"micromatch": "^3.1.10"
@@ -10148,32 +10200,32 @@
 			}
 		},
 		"gatsby-plugin-react-helmet": {
-			"version": "3.1.18",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.18.tgz",
-			"integrity": "sha512-wwKH6Z5NK0Gl2hDfMnWNGE41GjWpZGq0eKczPydTJc/1SbPykBFCBrjYgrAPB2ZrRnA8AV06cRwPddJC0mY7sw==",
+			"version": "3.1.21",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.21.tgz",
+			"integrity": "sha512-6LZ2LEYTwqD+ZqyCH55mVpk2xEXbQoCTfijP1W4ZCQsKtpWGJP+vyd6b96FWVyEb2k5LsQ1u+jk4R8xXULSX+w==",
 			"requires": {
 				"@babel/runtime": "^7.7.6"
 			}
 		},
 		"gatsby-plugin-sass": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-2.1.26.tgz",
-			"integrity": "sha512-zunowxeYrtPIiMkgIHZLTNvwzSLJmBBSH+2EQEtyKgdOlB2tWcXp+/ifoWaYRCMykMGsTvvyn4kNIyl5bslBDw==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-2.1.27.tgz",
+			"integrity": "sha512-VOp1+eGRGEYYjUnWR/PufEYgXsrALQD4yjdk47UfUfiazc/xwrs0nMxPX9YXoGyV3lkBbVCAfEU3Nit7flpY/Q==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"sass-loader": "^7.3.1"
 			}
 		},
 		"gatsby-plugin-sharp": {
-			"version": "2.3.10",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.3.10.tgz",
-			"integrity": "sha512-uoVLdSnnrnpWxeI+ZNdQ7nuvx60LI8+nqsuUu0KfyAmEhNgcuuExTDYlM4WDn1BCIifCylTwBBTP0xZU4YvPeA==",
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.4.4.tgz",
+			"integrity": "sha512-i8xY612UIHjOT78SD+FAkR7Wov4/pHn+2DJ7SiSvv7I3Pb1PTKm3XksvNKbKxFMjAfUROehqsRbYCIZIDaff5Q==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"async": "^2.6.3",
 				"bluebird": "^3.7.2",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"got": "^8.3.2",
 				"imagemin": "^6.1.0",
 				"imagemin-mozjpeg": "^8.0.0",
@@ -10181,7 +10233,6 @@
 				"imagemin-webp": "^5.1.0",
 				"lodash": "^4.17.15",
 				"mini-svg-data-uri": "^1.1.3",
-				"p-defer": "^3.0.0",
 				"potrace": "^2.1.2",
 				"probe-image-size": "^4.1.1",
 				"progress": "^2.0.3",
@@ -10198,18 +10249,13 @@
 					"requires": {
 						"lodash": "^4.17.14"
 					}
-				},
-				"p-defer": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-					"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 				}
 			}
 		},
 		"gatsby-react-router-scroll": {
-			"version": "2.1.19",
-			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
-			"integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
+			"version": "2.1.20",
+			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.20.tgz",
+			"integrity": "sha512-o4LvoV+XL8zLLFsX1rN2Und4seu2jppEcj6yb9g/f5itsPzNXMdRWW8r2fqovGRxtDJ/J6Wwx+1y3pOokMSq/A==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"scroll-behavior": "^0.9.10",
@@ -10217,9 +10263,9 @@
 			}
 		},
 		"gatsby-remark-autolink-headers": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.21.tgz",
-			"integrity": "sha512-2GvQrlmkxduU9ZFMoU7o2Psb1kAFN8Wh4Fhqdj3WSNJwWmIYgGXs5xl+W6dLotjKwfL9Zxv8zHnx2HDxum6WCg==",
+			"version": "2.1.23",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-2.1.23.tgz",
+			"integrity": "sha512-OXZi/XlA8o0NmZLkPoMqM03cXNIymugCRfuqpZxZTXqGObjjbYb+YbxLVSbogbJAVJdjw2xVEjYMG1ca0YMS1w==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"github-slugger": "^1.2.1",
@@ -10239,9 +10285,9 @@
 			}
 		},
 		"gatsby-remark-copy-linked-files": {
-			"version": "2.1.33",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.33.tgz",
-			"integrity": "sha512-hRXwxlaFk39tfl2hCUL6vPg89IguQRfP+mrfJzyoDN3urFFVuw8D3+98xALaoidah6o9PIqtUEphvX1V6YKKTw==",
+			"version": "2.1.36",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.36.tgz",
+			"integrity": "sha512-WEvdRLvWHr8ftrHUfq/77N0AbraGN62fkWe4E+p8/SKPCXb7WV7sY67Z/npiBAh6bRMNWsy/UZpKEkOk/oz04A==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"cheerio": "^1.0.0-rc.3",
@@ -10264,9 +10310,9 @@
 			}
 		},
 		"gatsby-remark-prismjs": {
-			"version": "3.3.28",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.28.tgz",
-			"integrity": "sha512-EyuuDo221FlO2Ekb2QRjAcofKZ2InHJxalbWnocAbkZFsMRNsJ2jENjD4bgI8nSQnbdY3vyBeyHm8+owlJTtVw==",
+			"version": "3.3.30",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.30.tgz",
+			"integrity": "sha512-DFcFAcvYHmx9FM5P/CRkCbQH4nSPmZ9DRaocAUxH7ZJtF2nMGYp1suYa8BEJKmM/EwvFxLdGoRoN+5FzO56qZQ==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"parse-numeric-range": "^0.0.2",
@@ -10284,9 +10330,9 @@
 			}
 		},
 		"gatsby-source-filesystem": {
-			"version": "2.1.43",
-			"resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.43.tgz",
-			"integrity": "sha512-lmq64xMgHE6cXwLgddogcx2THPsMCia/HivWRGK6DCJhCOXDbkWSiNYthpMIgZXkfsGaYFiVjxRZSSn1QVOU9g==",
+			"version": "2.1.47",
+			"resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.47.tgz",
+			"integrity": "sha512-25WktQN4XUpknVkwwvIio80ZEg3tEQISOsU6N81fI0tpxLPss9iShplGQvuA3K4dsewV+CTHQs3t3vyMGSaNYg==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"better-queue": "^3.8.10",
@@ -10294,7 +10340,7 @@
 				"chokidar": "3.3.0",
 				"file-type": "^12.4.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"got": "^7.1.0",
 				"md5-file": "^3.2.3",
 				"mime": "^2.4.4",
@@ -10370,9 +10416,9 @@
 			}
 		},
 		"gatsby-telemetry": {
-			"version": "1.1.46",
-			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.46.tgz",
-			"integrity": "sha512-HFrrZc/mZtzt2DsMc34HZiIEHpaXt1kKcFZC6s3Q3KqkgUweCZMwE7N52jkhGA+c3aFOZU/D+CtyP9dWcrsM/Q==",
+			"version": "1.1.48",
+			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.48.tgz",
+			"integrity": "sha512-DD1gzel0HBVKB7kMMMV9YpmvSASf9zTLL2qf9ZFegI2NNrwXfE5buBIBNRef0veLaRXQvamu+ni0CRzumG2Bfw==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"@babel/runtime": "^7.7.6",
@@ -10381,7 +10427,7 @@
 				"configstore": "^5.0.0",
 				"envinfo": "^7.5.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"git-up": "4.0.1",
 				"is-docker": "2.0.0",
 				"lodash": "^4.17.15",
@@ -10442,6 +10488,11 @@
 						"crypto-random-string": "^2.0.0"
 					}
 				},
+				"uuid": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+					"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+				},
 				"write-file-atomic": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
@@ -10461,13 +10512,13 @@
 			}
 		},
 		"gatsby-transformer-remark": {
-			"version": "2.6.45",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.45.tgz",
-			"integrity": "sha512-3oICZvZmQyecK+vGBpcLOuDMpJio2OsJEGnmEXlQuS0KOWALGvZCfu3sNu4ROHemEgwY8q5z7OANjqZVxIaloQ==",
+			"version": "2.6.49",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.49.tgz",
+			"integrity": "sha512-tnXzdgBOGYKmzwS+u8BlJY7GkgUt89QcL5zSVjXlYwFD9nye3eGX6SumtpbbJc7pGDdkl1CWpBtj3Kifajb3JA==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"bluebird": "^3.7.2",
-				"gatsby-core-utils": "^1.0.25",
+				"gatsby-core-utils": "^1.0.27",
 				"gray-matter": "^4.0.2",
 				"hast-util-raw": "^4.0.0",
 				"hast-util-to-html": "^4.0.1",
@@ -10478,7 +10529,7 @@
 				"remark": "^10.0.1",
 				"remark-parse": "^6.0.3",
 				"remark-retext": "^3.1.3",
-				"remark-stringify": "^5.0.0",
+				"remark-stringify": "6.0.4",
 				"retext-english": "^3.0.4",
 				"sanitize-html": "^1.20.1",
 				"underscore.string": "^3.3.5",
@@ -10503,27 +10554,6 @@
 						"unified": "^7.0.0"
 					},
 					"dependencies": {
-						"remark-stringify": {
-							"version": "6.0.4",
-							"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
-							"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
-							"requires": {
-								"ccount": "^1.0.0",
-								"is-alphanumeric": "^1.0.0",
-								"is-decimal": "^1.0.0",
-								"is-whitespace-character": "^1.0.0",
-								"longest-streak": "^2.0.1",
-								"markdown-escapes": "^1.0.0",
-								"markdown-table": "^1.1.0",
-								"mdast-util-compact": "^1.0.0",
-								"parse-entities": "^1.0.2",
-								"repeat-string": "^1.5.4",
-								"state-toggle": "^1.0.0",
-								"stringify-entities": "^1.0.1",
-								"unherit": "^1.0.4",
-								"xtend": "^4.0.1"
-							}
-						},
 						"unified": {
 							"version": "7.1.0",
 							"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
@@ -10564,9 +10594,9 @@
 					}
 				},
 				"remark-stringify": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-5.0.0.tgz",
-					"integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
+					"version": "6.0.4",
+					"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+					"integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
 					"requires": {
 						"ccount": "^1.0.0",
 						"is-alphanumeric": "^1.0.0",
@@ -10661,9 +10691,9 @@
 			}
 		},
 		"gatsby-transformer-sharp": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.9.tgz",
-			"integrity": "sha512-R5mZyniGAxMd7MA46l4eCdrRT9vP5Uz5TbaKdOWMAXpTu1KLFyRQAigjtcINV/haC4xS8Q4NezdpxpZ2Bw8DHg==",
+			"version": "2.3.13",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.13.tgz",
+			"integrity": "sha512-jof7b1btkABcsN6lP5qd7cBMffPFv09qTKs6ZTgRIRB9jQBiBizJydmyT97eCqqIl0dKIr8/5Bt/eC6jyxMj8A==",
 			"requires": {
 				"@babel/runtime": "^7.7.6",
 				"bluebird": "^3.7.2",
@@ -10729,6 +10759,11 @@
 			"requires": {
 				"globule": "^1.0.0"
 			}
+		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -10934,9 +10969,9 @@
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globby": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-			"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+			"integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
 			"requires": {
 				"@types/glob": "^7.1.1",
 				"array-union": "^2.1.0",
@@ -11086,9 +11121,9 @@
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
 		},
 		"graphql": {
-			"version": "14.5.8",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
-			"integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+			"integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
 			"requires": {
 				"iterall": "^1.2.2"
 			}
@@ -11189,17 +11224,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
 			"integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
-		},
-		"handlebars": {
-			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
-			}
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -11354,6 +11378,22 @@
 				"minimalistic-assert": "^1.0.1"
 			}
 		},
+		"hasha": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+			"integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
+			"requires": {
+				"is-stream": "^2.0.0",
+				"type-fest": "^0.8.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+				}
+			}
+		},
 		"hast-to-hyperscript": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/hast-to-hyperscript/-/hast-to-hyperscript-5.0.0.tgz",
@@ -11497,9 +11537,9 @@
 			}
 		},
 		"hoist-non-react-statics": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-			"integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -11534,9 +11574,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -11590,10 +11630,15 @@
 			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
 			"integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
 		},
+		"html-escaper": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+			"integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig=="
+		},
 		"html-void-elements": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.4.tgz",
-			"integrity": "sha512-yMk3naGPLrfvUV9TdDbuYXngh/TpHbA6TrOw3HL9kS8yhwx7i309BReNg7CbAJXGE+UMJ6je5OqJ7lC63o6YuQ=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-1.0.5.tgz",
+			"integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
 		},
 		"htmlhint": {
 			"version": "0.11.0",
@@ -11836,22 +11881,12 @@
 			"integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
 		},
 		"https-proxy-agent": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
-			"integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
 			"requires": {
-				"agent-base": "^4.3.0",
-				"debug": "^3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				}
+				"agent-base": "5",
+				"debug": "4"
 			}
 		},
 		"human-signals": {
@@ -12713,9 +12748,9 @@
 			}
 		},
 		"inquirer": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
-			"integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
+			"integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
 			"requires": {
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^2.4.2",
@@ -12900,9 +12935,9 @@
 			}
 		},
 		"is-alphabetical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
 		},
 		"is-alphanumeric": {
 			"version": "1.0.0",
@@ -12910,9 +12945,9 @@
 			"integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
 		},
 		"is-alphanumerical": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -13019,9 +13054,9 @@
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-decimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -13102,9 +13137,9 @@
 			}
 		},
 		"is-hexadecimal": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -13224,9 +13259,9 @@
 			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
 		},
 		"is-plain-obj": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-			"integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -13357,9 +13392,9 @@
 			}
 		},
 		"is-whitespace-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
-			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -13367,9 +13402,9 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-word-character": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
-			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
 		},
 		"is-wsl": {
 			"version": "1.1.0",
@@ -13499,11 +13534,11 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-			"integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+			"integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
 			"requires": {
-				"handlebars": "^4.1.2"
+				"html-escaper": "^2.0.0"
 			}
 		},
 		"isurl": {
@@ -13516,9 +13551,9 @@
 			}
 		},
 		"iterall": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
-			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
 		"jest": {
 			"version": "24.0.0",
@@ -14682,10 +14717,10 @@
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
 			"integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
 		},
-		"js-levenshtein": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
-			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="
+		"js-cookie": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+			"integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -14755,9 +14790,9 @@
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"jshint": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.3.tgz",
-			"integrity": "sha512-d8AoXcNNYzmm7cdmulQ3dQApbrPYArtVBO6n4xOICe4QsXGNHCAKDcFORzqP52LhK61KX0VhY39yYzCsNq+bxQ==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
+			"integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
 			"optional": true,
 			"requires": {
 				"cli": "~1.0.0",
@@ -14900,9 +14935,9 @@
 			"integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
 		},
 		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"kleur": {
 			"version": "3.0.3",
@@ -14943,6 +14978,14 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+		},
+		"levenary": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+			"requires": {
+				"leven": "^3.1.0"
+			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -15668,11 +15711,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
 			"integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
 		},
-		"lodash.unescape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
-		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -15801,9 +15839,9 @@
 			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
 		},
 		"longest-streak": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
-			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw=="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg=="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -15891,6 +15929,13 @@
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 			"requires": {
 				"p-defer": "^1.0.0"
+			},
+			"dependencies": {
+				"p-defer": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+					"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+				}
 			}
 		},
 		"map-cache": {
@@ -15912,9 +15957,9 @@
 			}
 		},
 		"markdown-escapes": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
-			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
 		},
 		"markdown-link-extractor": {
 			"version": "1.2.2",
@@ -16050,9 +16095,9 @@
 			"integrity": "sha512-P+gdtssCoHOX+eJUrrC30Sixqao86ZPlVjR5NEAoy0U79Pfxb1Y0Gntei0+GrnQD4T04X9xA8tcugp90cSmNow=="
 		},
 		"mdast-util-toc": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.0.0.tgz",
-			"integrity": "sha512-1ExJKC+85/+Q2LfuASOjdGTB7n/ikQperjiv+7OEVCpRbabr/DGZzEXEZfsZr/k4Pd3g/Gim9DV44/rPjczMAw==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-toc/-/mdast-util-toc-5.0.1.tgz",
+			"integrity": "sha512-icdxfPSLPJuK0Qd7w2+X9qcsPl9fVdpiEAjhS4zBp7WbNhpkorodXPUG0ZG4N5E++q4+IidV2boJpcCF985xlA==",
 			"requires": {
 				"@types/mdast": "^3.0.3",
 				"@types/unist": "^2.0.3",
@@ -16115,9 +16160,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -16299,16 +16344,16 @@
 			"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
 		},
 		"mime-db": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-			"integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.25",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-			"integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
-				"mime-db": "1.42.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"mimic-fn": {
@@ -16472,9 +16517,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -16707,9 +16752,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
-			"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+			"integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
 		},
 		"node-gyp": {
 			"version": "3.8.0",
@@ -16817,9 +16862,9 @@
 					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -16890,9 +16935,9 @@
 			"integrity": "sha512-VZR0zroAusy1ETZMZiGeLkdu50LGjG5U1KHZqTruqtTyQ2wfWhHG2Ow4nsUbfTFGlaREgNHcCWoM/OzEm6p+NQ=="
 		},
 		"node-releases": {
-			"version": "1.1.44",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.44.tgz",
-			"integrity": "sha512-NwbdvJyR7nrcGrXvKAvzc5raj/NkoJudkarh2yIpJ4t0NH4aqjUDz/486P+ynIW5eokKOfzGNRdYoLfBlomruw==",
+			"version": "1.1.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+			"integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
 			"requires": {
 				"semver": "^6.3.0"
 			},
@@ -16905,9 +16950,9 @@
 			}
 		},
 		"node-sass": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
-			"integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.1.tgz",
+			"integrity": "sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==",
 			"requires": {
 				"async-foreach": "^0.1.3",
 				"chalk": "^1.1.1",
@@ -17337,15 +17382,6 @@
 				"is-wsl": "^1.1.0"
 			}
 		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
-			}
-		},
 		"optimize-css-assets-webpack-plugin": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.3.tgz",
@@ -17424,9 +17460,9 @@
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 		},
 		"p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 		},
 		"p-each-series": {
 			"version": "1.0.0",
@@ -17554,9 +17590,9 @@
 			}
 		},
 		"pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
 		},
 		"parallel-transform": {
 			"version": "1.2.0",
@@ -17574,9 +17610,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -17643,9 +17679,9 @@
 			}
 		},
 		"parse-english": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.2.tgz",
-			"integrity": "sha512-+PBf+1ifxqJlOpisODiKX4A8wBEgWm4goMvDB5O9zx/cQI58vzHTZeWFbAgCF9fUXRl8/YdINv1cfmfIRR1acg==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/parse-english/-/parse-english-4.1.3.tgz",
+			"integrity": "sha512-IQl1v/ik9gw437T8083coohMihae0rozpc7JYC/9h6hi9xKBSxFwh5HWRpzVC2ZhEs2nUlze2aAktpNBJXdJKA==",
 			"requires": {
 				"nlcst-to-string": "^2.0.0",
 				"parse-latin": "^4.0.0",
@@ -17707,9 +17743,9 @@
 			}
 		},
 		"parse-latin": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.2.0.tgz",
-			"integrity": "sha512-b8PvsA1Ohh7hIQwDDy6kSjx3EbcuR3oKYm5lC1/l/zIB6mVVV5ESEoS1+Qr5+QgEGmp+aEZzc+D145FIPJUszw==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.2.1.tgz",
+			"integrity": "sha512-7T9g6mIsFFpLlo0Zzb2jLWdCt+H9Qtf/hRmMYFi/Mq6Ovi+YKo+AyDFX3OhFfu0vXX5Nid9FKJGKSSzNcTkWiA==",
 			"requires": {
 				"nlcst-to-string": "^2.0.0",
 				"unist-util-modify-children": "^1.0.0",
@@ -17885,9 +17921,9 @@
 			"integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA="
 		},
 		"picomatch": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-			"integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
 		},
 		"pify": {
 			"version": "3.0.0",
@@ -17983,9 +18019,9 @@
 			}
 		},
 		"pnp-webpack-plugin": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.5.0.tgz",
-			"integrity": "sha512-jd9olUr9D7do+RN8Wspzhpxhgp1n6Vd0NtQ4SFkmIACZoEL1nkyAdW9Ygrinjec0vgDcWjscFQQ1gDW8rsfKTg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.0.tgz",
+			"integrity": "sha512-ZcMGn/xF/fCOq+9kWMP9vVVxjIkMCja72oy3lziR7UHy0hHFZ57iVpQ71OtveVbmzeCmphBg8pxNdk/hlK99aQ==",
 			"requires": {
 				"ts-pnp": "^1.1.2"
 			}
@@ -18102,13 +18138,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"postcss-value-parser": {
@@ -18324,13 +18360,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"postcss-selector-parser": {
@@ -18393,13 +18429,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"postcss-value-parser": {
@@ -18725,13 +18761,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"postcss-value-parser": {
@@ -18809,13 +18845,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				}
 			}
@@ -18982,9 +19018,9 @@
 			}
 		},
 		"prismjs": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-			"integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.19.0.tgz",
+			"integrity": "sha512-IVFtbW9mCWm9eOIaEkNyo2Vl4NnEifis2GQ7/MLRG5TQe6t+4Sj9J5QWI9i3v+SS43uZBlCAOn+zYTVYQcPXJw==",
 			"requires": {
 				"clipboard": "^2.0.0"
 			}
@@ -19150,14 +19186,16 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"puppeteer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.0.0.tgz",
-			"integrity": "sha512-t3MmTWzQxPRP71teU6l0jX47PHXlc4Z52sQv4LJQSZLq1ttkKS2yGM3gaI57uQwZkNaoGd0+HPPMELZkcyhlqA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.0.tgz",
+			"integrity": "sha512-PC4oKMtwAElo8YtS/cYnk2/dew/3TonsGKKzjpFLWwkhBCteFsOZCVOXTt2QlP6w53mH0YsJE+fPLPzOW+DCug==",
 			"requires": {
+				"@types/mime-types": "^2.1.0",
 				"debug": "^4.1.0",
 				"extract-zip": "^1.6.6",
-				"https-proxy-agent": "^3.0.0",
+				"https-proxy-agent": "^4.0.0",
 				"mime": "^2.0.3",
+				"mime-types": "^2.1.25",
 				"progress": "^2.0.1",
 				"proxy-from-env": "^1.0.0",
 				"rimraf": "^2.6.1",
@@ -19263,12 +19301,19 @@
 			}
 		},
 		"rdf-canonize": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.0.3.tgz",
-			"integrity": "sha512-piLMOB5Q6LJSVx2XzmdpHktYVb8TmVTy8coXJBFtdkcMC96DknZOuzpAYqCWx2ERZX7xEW+mMi8/wDuMJS/95w==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.1.0.tgz",
+			"integrity": "sha512-DV06OnhVfl2zcZJQCt+YvU+hoZVgpyQpNFLeAmghq8RJybUxD3B4LRzlBquYS5k+LLd8/c3g5Gnhkqjw5qRMvg==",
 			"requires": {
-				"node-forge": "^0.8.1",
-				"semver": "^5.6.0"
+				"node-forge": "^0.9.1",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"react": {
@@ -19590,9 +19635,9 @@
 			}
 		},
 		"react-hot-loader": {
-			"version": "4.12.18",
-			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.18.tgz",
-			"integrity": "sha512-qYD0Qi9lIbg9jLyfmodfqvAQqCBsoPKxAhca8Nxvy2/2pO5Q9r2kM28jN0bbbSnhwK8dJ7FjsfVtXKOxMW+bqw==",
+			"version": "4.12.19",
+			"resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.19.tgz",
+			"integrity": "sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==",
 			"requires": {
 				"fast-levenshtein": "^2.0.6",
 				"global": "^4.3.0",
@@ -19653,13 +19698,15 @@
 			}
 		},
 		"react-use": {
-			"version": "13.13.0",
-			"resolved": "https://registry.npmjs.org/react-use/-/react-use-13.13.0.tgz",
-			"integrity": "sha512-J3/h5wvL6vXmecAvEnninCC3DviLMRWcQrEnouTliwws1b376DQKEgIFuTXlF8c3SKpXBQJdDDm1RpluokW6ag==",
+			"version": "13.22.4",
+			"resolved": "https://registry.npmjs.org/react-use/-/react-use-13.22.4.tgz",
+			"integrity": "sha512-DrbU7Q6DBUhjXa4xJEFuAcnO34PpIpoXP5YQhsjAI8jZjS6z7pX7Q4YISBhSjDlTu2zXR3Qy1LTgOPEMAARMbQ==",
 			"requires": {
-				"@xobotyi/scrollbar-width": "1.5.0",
+				"@types/js-cookie": "2.2.4",
+				"@xobotyi/scrollbar-width": "1.8.2",
 				"copy-to-clipboard": "^3.2.0",
-				"fast-shallow-equal": "^0.1.1",
+				"fast-shallow-equal": "^1.0.0",
+				"js-cookie": "^2.2.1",
 				"nano-css": "^5.2.1",
 				"react-fast-compare": "^2.0.4",
 				"resize-observer-polyfill": "^1.5.1",
@@ -19724,9 +19771,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+			"integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -19840,9 +19887,9 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -19999,12 +20046,11 @@
 			}
 		},
 		"registry-auth-token": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-			"integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+			"integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
 			"requires": {
-				"rc": "^1.2.8",
-				"safe-buffer": "^5.0.1"
+				"rc": "^1.2.8"
 			}
 		},
 		"registry-url": {
@@ -20043,6 +20089,15 @@
 				"remark-parse": "^7.0.0",
 				"remark-stringify": "^7.0.0",
 				"unified": "^8.2.0"
+			}
+		},
+		"remark-frontmatter": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-1.3.2.tgz",
+			"integrity": "sha512-2eayxITZ8rezsXdgcXnYB3iLivohm2V/ZT4Ne8uhua6A4pk6GdLE2ZzJnbnINtD1HRLaTdB7RwF9sgUbMptJZA==",
+			"requires": {
+				"fault": "^1.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remark-parse": {
@@ -20233,9 +20288,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-			"integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
+			"integrity": "sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -20538,9 +20593,9 @@
 			}
 		},
 		"sanitize-html": {
-			"version": "1.20.1",
-			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
-			"integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
+			"version": "1.21.1",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.21.1.tgz",
+			"integrity": "sha512-W6enXSVphVaVbmVbzVngBthR5f5sMmhq3EfPfBlzBzp2WnX8Rnk7NGpP7KmHUc0Y3MVk9tv/+CbpdHchX9ai7g==",
 			"requires": {
 				"chalk": "^2.4.1",
 				"htmlparser2": "^3.10.0",
@@ -20864,9 +20919,9 @@
 			}
 		},
 		"screenfull": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.0.tgz",
-			"integrity": "sha512-yShzhaIoE9OtOhWVyBBffA6V98CDCoyHTsp8228blmqYy1Z5bddzE/4FPiJKlr8DVR4VBiiUyfPzIQPIYDkeMA=="
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.1.tgz",
+			"integrity": "sha512-NgQH4KKh2V3zlj2u90l7TUcSFxr9qL/64QEvhAvCN/fu1YS39YLTBKIqZqiS3STj3QD8sN6XnsK/8jk3hRq4WA=="
 		},
 		"scroll-behavior": {
 			"version": "0.9.11",
@@ -21668,14 +21723,14 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sourcemap-codec": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-			"integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
 		},
 		"space-separated-tokens": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
-			"integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+			"integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -21845,11 +21900,11 @@
 			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
 		},
 		"stack-generator": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.4.tgz",
-			"integrity": "sha512-ha1gosTNcgxwzo9uKTQ8zZ49aUp5FIUW58YHFxCqaAHtE0XqBg0chGFYA1MfmW//x1KWq3F4G7Ug7bJh4RiRtg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+			"integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
 			"requires": {
-				"stackframe": "^1.1.0"
+				"stackframe": "^1.1.1"
 			}
 		},
 		"stack-trace": {
@@ -21863,17 +21918,17 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
 		},
 		"stackframe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.0.tgz",
-			"integrity": "sha512-Vx6W1Yvy+AM1R/ckVwcHQHV147pTPBKWCRLrXMuPrFVfvBUc3os7PR1QLIWCMhPpRg5eX9ojzbQIMLGBwyLjqg=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.1.1.tgz",
+			"integrity": "sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ=="
 		},
 		"stacktrace-gps": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.3.tgz",
-			"integrity": "sha512-51Rr7dXkyFUKNmhY/vqZWK+EvdsfFSRiQVtgHTFlAdNIYaDD7bVh21yBHXaNWAvTD+w+QSjxHg7/v6Tz4veExA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+			"integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
 			"requires": {
 				"source-map": "0.5.6",
-				"stackframe": "^1.1.0"
+				"stackframe": "^1.1.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -21884,19 +21939,19 @@
 			}
 		},
 		"stacktrace-js": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.1.tgz",
-			"integrity": "sha512-13oDNgBSeWtdGa4/2BycNyKqe+VktCoJ8VLx4pDoJkwGGJVtiHdfMOAj3aW9xTi8oR2v34z9IcvfCvT6XNdNAw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+			"integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
 			"requires": {
-				"error-stack-parser": "^2.0.4",
-				"stack-generator": "^2.0.4",
-				"stacktrace-gps": "^3.0.3"
+				"error-stack-parser": "^2.0.6",
+				"stack-generator": "^2.0.5",
+				"stacktrace-gps": "^3.0.4"
 			}
 		},
 		"state-toggle": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
-			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -21960,9 +22015,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -22008,9 +22063,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -22072,9 +22127,9 @@
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				},
 				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"version": "2.3.7",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+					"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
 					"requires": {
 						"core-util-is": "~1.0.0",
 						"inherits": "~2.0.3",
@@ -22351,13 +22406,13 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.8.2",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-					"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+					"version": "4.8.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
+					"integrity": "sha512-ZHao85gf0eZ0ESxLfCp73GG9O/VTytYDIkIiZDlURppLTI9wErSM/5yAKEq6rcUdxBLjMELmrYUJGg5sxGKMHg==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001015",
-						"electron-to-chromium": "^1.3.322",
-						"node-releases": "^1.1.42"
+						"caniuse-lite": "^1.0.30001023",
+						"electron-to-chromium": "^1.3.341",
+						"node-releases": "^1.1.47"
 					}
 				},
 				"postcss-selector-parser": {
@@ -22544,9 +22599,9 @@
 			"integrity": "sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A=="
 		},
 		"terser": {
-			"version": "4.4.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.4.3.tgz",
-			"integrity": "sha512-0ikKraVtRDKGzHrzkCv5rUNDzqlhmhowOBqC0XqUHFpW+vJ45+20/IFBcebwKfiS2Z9fJin6Eo+F1zLZsxi8RA==",
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+			"integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
 			"requires": {
 				"commander": "^2.20.0",
 				"source-map": "~0.6.1",
@@ -22791,9 +22846,9 @@
 			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
 		},
 		"trim-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
-			"integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
+			"integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA=="
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
@@ -22809,14 +22864,14 @@
 			}
 		},
 		"trim-trailing-lines": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
-			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+			"integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
 		},
 		"trough": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
-			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
 		},
 		"true-case-path": {
 			"version": "2.2.1",
@@ -22905,32 +22960,14 @@
 			}
 		},
 		"typescript": {
-			"version": "3.7.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-			"integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
+			"version": "3.7.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
 			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
-		},
-		"uglify-js": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
-			"integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
-			"optional": true,
-			"requires": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				}
-			}
 		},
 		"unbzip2-stream": {
 			"version": "1.3.3",
@@ -22967,12 +23004,12 @@
 			}
 		},
 		"unherit": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
-			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
 			"requires": {
-				"inherits": "^2.0.1",
-				"xtend": "^4.0.1"
+				"inherits": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"unicode-canonical-property-names-ecmascript": {
@@ -23524,12 +23561,14 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
-			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.2",
+				"has-symbols": "^1.0.1",
+				"object.getownpropertydescriptors": "^2.1.0"
 			}
 		},
 		"utila": {
@@ -23543,9 +23582,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "1.1.2",
@@ -23572,9 +23611,9 @@
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"vendors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
-			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
+			"integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w=="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -23771,9 +23810,9 @@
 			}
 		},
 		"web-namespaces": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.3.tgz",
-			"integrity": "sha512-r8sAtNmgR0WKOKOxzuSgk09JsHlpKlB+uHi937qypOu3PZ17UxPrierFKDye/uNHjNTTEshu5PId8rojIPj/tA=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
+			"integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",
@@ -24548,11 +24587,6 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
 		},
-		"wordwrap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-		},
 		"worker-farm": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -24702,9 +24736,9 @@
 			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
 		},
 		"xstate": {
-			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.5.tgz",
-			"integrity": "sha512-1QbwTUviBCHSnT3ct+GZZspzbNsftMEzP1lXmeR/zJphA1BHeLh/JV+woCmRdTBHyuGcJ2I7u7pp/+Y9e4qq9A=="
+			"version": "4.7.7",
+			"resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.7.tgz",
+			"integrity": "sha512-ctV7gShkDe+HOLP1MV78FRqWhNtmMJvtGjlgP10N6MeELVxGbvc54WrwfBv0e/xyjSaqveM48Pohut71naqVNA=="
 		},
 		"xtend": {
 			"version": "4.0.2",
@@ -24795,9 +24829,9 @@
 			"optional": true
 		},
 		"yurnalist": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/yurnalist/-/yurnalist-1.1.1.tgz",
-			"integrity": "sha512-WMk8SL262zU/3Cr8twpfx/kdhPDAkhWN9HukNeb1U1xVrwU9iIAsCgYI8J5QMZTz+5N3Et/ZKzvOzVCjd/dAWA==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/yurnalist/-/yurnalist-1.1.2.tgz",
+			"integrity": "sha512-y7bsTXqL+YMJQ2De2CBtSftJNLQnB7gWIzzKm10GDyC8Fg4Dsmd2LG5YhT8pudvUiuotic80WVXt/g1femRVQg==",
 			"requires": {
 				"babel-runtime": "^6.26.0",
 				"chalk": "^2.4.2",
@@ -24844,9 +24878,9 @@
 					}
 				},
 				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+					"integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
 					"requires": {
 						"glob": "^7.1.3"
 					}
@@ -24880,9 +24914,9 @@
 			}
 		},
 		"zwitch": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.4.tgz",
-			"integrity": "sha512-YO803/X+13GNaZB7fVopjvHH0uWQKgJkgKnU1YCjxShjKGVuN9PPHHW8g+uFDpkHpSTNi3rCMKMewIcbC1BAYg=="
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
+			"integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -49,10 +49,12 @@
 		"react-helmet": "^5.2.1",
 		"react-media": "^1.10.0",
 		"react-use": "^13.12.2",
-		"remark": "^11.0.2",
-		"remove-markdown": "^0.3.0",
+		"remark-frontmatter": "^1.3.2",
+		"remark-parse": "^7.0.2",
 		"showdown": "^1.9.1",
-		"unist-util-visit": "^2.0.1"
+		"unified": "^8.4.2",
+		"unist-util-visit": "^2.0.1",
+		"vfile": "^4.0.2"
 	},
 	"devDependencies": {
 		"husky": "^3.1.0",

--- a/utils/get-markdown-data.js
+++ b/utils/get-markdown-data.js
@@ -2,7 +2,9 @@ const fs = require('fs')
 const globby = require('globby')
 const path = require('path')
 const fastmatter = require('fastmatter')
-const remark = require('remark')
+const unified = require('unified')
+const remarkParse = require('remark-parse')
+const remarkFrontmatter = require('remark-frontmatter')
 
 /**
  * Parse all markdown files in a given directory and construct metadata of each markdown file
@@ -13,8 +15,13 @@ const remark = require('remark')
 const getMarkdownData = dir => {
 	return globby.sync(`${dir}/**/*.md`).map(markdownPath => {
 		const filename = path.parse(markdownPath).base
+
 		const fileContents = fs.readFileSync(markdownPath, { encoding: 'utf-8' })
-		const markdownAST = remark.parse(fileContents)
+		const unifiedProcesser = unified()
+			.use(remarkParse)
+			.use(remarkFrontmatter)
+		const markdownAST = unifiedProcesser.parse(fileContents)
+
 		const { attributes: frontmatter, body } = fastmatter(fileContents)
 		return {
 			filename,


### PR DESCRIPTION
Apparently using `remark.parse` converted some of the frontmatter content to markdown AST in terms of computed some frontmatter as body content, and swapping to use using unified and specifying to treat frontmatter as its own content does the trick.
