### PR TITLE
chore: add git lfs support to track large files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
In attempting to zip and upload testcases as a zip, which is a fairly large file, git did not allow to push.

See here for logs:
https://github.com/act-rules/act-rules-web/runs/417639910?check_suite_focus=true

I followed docs here, https://git-lfs.github.com/ and this hopefully this should allow to push/ track large files.