### PR TITLE
feat: add script for producing a summary of wcag sc coverage

### DIFF
--- a/build/sc-coverage.js
+++ b/build/sc-coverage.js
@@ -1,0 +1,70 @@
+const assert = require('assert')
+const program = require('commander')
+const createFile = require('../utils/create-file')
+const getMarkdownData = require('../utils/get-markdown-data')
+const actRulesCommunityRulesDir = 'node_modules/act-rules-community/_rules'
+
+/**
+ * Parse `args`
+ */
+program
+	.option('-r, --rulesDir <rulesDir>', 'Directory containing rules markdown files')
+	.option('-o, --outputDir <outputDir>', 'output directory to create the meta data')
+	.parse(process.argv)
+
+/**
+ * Invoke
+ */
+init(program)
+	.catch(e => {
+		console.error(e)
+		process.exit(1)
+	})
+	.finally(() => console.info('Completed'))
+
+/**
+ * Create coverage list for wcag sc
+ */
+async function init(program) {
+	const { rulesDir, outputDir } = program
+
+	/**
+	 * assert `args`
+	 */
+	assert(rulesDir, '`rulesDir` is required')
+	assert(outputDir, '`outputDir` is required')
+
+	const rulesData = getMarkdownData(actRulesCommunityRulesDir)
+	const scs = {}
+	for (const { frontmatter } of rulesData) {
+		const { id: ruleId, name: ruleName, accessibility_requirements: ruleAccessibilityRequirements } = frontmatter
+		if (ruleAccessibilityRequirements) {
+			Object.keys(ruleAccessibilityRequirements)
+				.filter(r => r.includes('wcag'))
+				.forEach(r => {
+					if (ruleAccessibilityRequirements[r].forConformance) {
+						if (!scs[r]) {
+							scs[r] = []
+						}
+						const rule = `[${ruleId}]: ${ruleName}`
+						if (!scs[r].includes(rule)) {
+							scs[r].push(rule)
+						}
+					}
+				})
+		}
+	}
+	const res = []
+	Object.keys(scs).forEach(k => {
+		res.push({
+			sc: k,
+			rules: scs[k],
+		})
+	})
+	res.sort((a, b) => (a.sc > b.sc ? 1 : -1))
+
+	const out = {}
+	res.forEach(r => (out[r.sc] = r.rules))
+
+	await createFile(`${outputDir}/sc-coverage.json`, JSON.stringify(out, null, 2))
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 	"scripts": {
 		"getWcagMetaData": "node ./build/get-wcag-meta-data --url 'https://raw.githubusercontent.com/w3c/wai-wcag-quickref/gh-pages/_data/wcag21.json' --outputDir ${PWD}'/_data'",
 		"createTestcases": "node ./build/create-testcases --rulesDir $npm_package_config_actRulesCommunityRulesDir --testAssetsDir $npm_package_config_actRulesCommunityTestAssetsDir --actRulesCommunityPkgJson ${PWD}/$npm_package_config_actRulesCommunityPkgJson --outputDir ${PWD}'/_data/testcases'",
+		"sc-coverage": "node ./build/sc-coverage --rulesDir $npm_package_config_actRulesCommunityRulesDir --outputDir ${PWD}'/_data'",
 		"createGlossaryUsages": "node ./build/create-glossary-usages --rulesDir $npm_package_config_actRulesCommunityRulesDir --outputDir ${PWD}'/_data'",
 		"createRulesUsages": "node ./build/create-rules-usages.js --rulesDir $npm_package_config_actRulesCommunityRulesDir --outputDir ${PWD}'/_data'",
 		"pregetImplementationAxeCore": "npm --prefix './node_modules/act-rules-implementation-axe-core/' install && npm --prefix './node_modules/act-rules-implementation-axe-core/' run build -- --testsJson ${PWD}'/_data/testcases/testcases.json' --testsDir ${PWD}'/_data/testcases' --siteUrl $npm_package_www_url",


### PR DESCRIPTION
This script creates a quick overview of wcag sc coverage of the existing rules. It would be great to have it on the web site as well if you like the idea.