### PR TITLE
chore: added implementation wire-up for sortsite

### DIFF
--- a/implementations.yml
+++ b/implementations.yml
@@ -24,6 +24,12 @@
   testcases: ./_data/testcases/testcases.json
   output: ./_data/implementations/access-engine.json
 
+- organisation: 'PowerMapper'
+  toolName: 'SortSite'
+  jsonReports: ./node_modules/act-rules-implementation-sortsite/report.json
+  testcases: ./_data/testcases/testcases.json
+  output: ./_data/implementations/sortsite.json
+
 - organisation: 'Siteimprove'
   toolName: 'Alfa'
   jsonReports: ./node_modules/act-rules-implementation-alfa/report.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2686,6 +2686,10 @@
 			"version": "github:act-rules/act-rules-implementation-rgaa#a01d13f6fe3ba673e776317caf49c723ea6c45d6",
 			"from": "github:act-rules/act-rules-implementation-rgaa"
 		},
+		"act-rules-implementation-sortsite": {
+			"version": "github:act-rules/act-rules-implementation-sortsite#9bad426232ee9178a7ae7babff7744e3bbfbaaae",
+			"from": "github:act-rules/act-rules-implementation-sortsite"
+		},
 		"act-rules-implementation-trusted-tester": {
 			"version": "github:act-rules/act-rules-implementation-trusted-tester#18654831fdf4e6325de72364c81206f899d4fbbe",
 			"from": "github:act-rules/act-rules-implementation-trusted-tester"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"act-rules-implementation-mapper": "github:act-rules/act-rules-implementation-mapper",
 		"act-rules-implementation-qualweb": "github:act-rules/act-rules-implementation-qualweb",
 		"act-rules-implementation-rgaa": "github:act-rules/act-rules-implementation-rgaa",
+		"act-rules-implementation-sortsite": "github:act-rules/act-rules-implementation-sortsite",
 		"act-rules-implementation-trusted-tester": "github:act-rules/act-rules-implementation-trusted-tester",
 		"axios": "^0.19.0",
 		"classnames": "^2.2.6",


### PR DESCRIPTION
Here's a PR to add our implementation report to the ACT Rules website.

npm install made some changes to package-lock.json (updated some requires versions and added an axe dependency) that didn't look relevant so they're not in the PR

