### PR TITLE
fix: update `acknowledgment` component

### DIFF
--- a/src/components/acknowledgments.js
+++ b/src/components/acknowledgments.js
@@ -15,11 +15,11 @@ import PropTypes from 'prop-types'
  *
  * @param {Object} props Props
  */
-const Acknowledgements = ({ scrollLinkId, items, contributors }) => {
-	const preferredAcknowledgementsOrder = ['authors', 'previous_authors', 'reviewers', 'funding']
+const Acknowledgments = ({ scrollLinkId, items, contributors }) => {
+	const preferredAcknowledgmentsOrder = ['authors', 'previous_authors', 'reviewers', 'funding']
 
 	const otherItems = Object.keys(items).reduce((out, key) => {
-		if (!preferredAcknowledgementsOrder.includes(key)) {
+		if (!preferredAcknowledgmentsOrder.includes(key)) {
 			out[key] = items[key]
 		}
 		return out
@@ -36,7 +36,7 @@ const Acknowledgements = ({ scrollLinkId, items, contributors }) => {
 	return (
 		<>
 			<a id={scrollLinkId} href={`#${scrollLinkId}`}>
-				<h2>Acknowledgements</h2>
+				<h2>Acknowledgments</h2>
 			</a>
 			{Object.keys(curatedItems).map(key => {
 				const values = curatedItems[key] || []
@@ -70,13 +70,13 @@ const Acknowledgements = ({ scrollLinkId, items, contributors }) => {
 	)
 }
 
-Acknowledgements.propTypes = {
+Acknowledgments.propTypes = {
 	scrollLinkId: PropTypes.string.isRequired,
 	items: PropTypes.object.isRequired,
 	contributors: PropTypes.array.isRequired,
 }
 
-Acknowledgements.defaultProps = {
+Acknowledgments.defaultProps = {
 	scrollLinkId: ``,
 	items: {
 		authors: [],
@@ -86,4 +86,4 @@ Acknowledgements.defaultProps = {
 	contributors: [],
 }
 
-export default Acknowledgements
+export default Acknowledgments

--- a/src/components/rule-table-of-contents.js
+++ b/src/components/rule-table-of-contents.js
@@ -26,7 +26,7 @@ const RuleTableOfContents = ({ toc }) => {
 					<a href="#implementation-metrics">Implementations</a>
 				</li>
 				<li>
-					<a href="#acknowledgements">Acknowledgements</a>
+					<a href="#acknowledgments">Acknowledgments</a>
 				</li>
 			</ul>
 		</section>

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -4,7 +4,7 @@ import showdown from 'showdown'
 
 import SEO from '../components/seo'
 import Layout from '../components/layout'
-import Acknowledgements from '../components/acknowledgements'
+import Acknowledgments from '../components/acknowledgments'
 import AccessibilityRequirements from '../components/accessibility_requirements'
 import ListOfImplementers from '../components/list-of-implementers'
 import RuleTableOfContents from '../components/rule-table-of-contents'
@@ -29,7 +29,7 @@ export default ({ location, data }) => {
 	const { slug, fastmatterAttributes, changelog, fileName } = fields
 	const { relativePath } = fileName
 	const ruleChangelog = JSON.parse(changelog)
-	const { accessibility_requirements, acknowledgements } = JSON.parse(fastmatterAttributes)
+	const parsedFrontmatter = JSON.parse(fastmatterAttributes)
 	const converter = new showdown.Converter()
 	const { repository, config, contributors } = JSON.parse(site.siteMetadata.actRulesPackage)
 	const repositoryUrl = curateGitUrl(repository.url)
@@ -78,7 +78,7 @@ export default ({ location, data }) => {
 						</span>
 					</li>
 					<li>
-						<AccessibilityRequirements accessibility_requirements={accessibility_requirements} />
+						<AccessibilityRequirements accessibility_requirements={parsedFrontmatter.accessibility_requirements} />
 					</li>
 					<li>{getRuleUsageInRules(ruleId)}</li>
 					<li>{getInputAspects(frontmatter.input_aspects, ruleFormatInputAspects)}</li>
@@ -146,8 +146,12 @@ export default ({ location, data }) => {
 					</a>
 					<ListOfImplementers implementers={validImplementers} ruleId={ruleId} />
 				</>
-				{/* acknowledgements */}
-				<Acknowledgements scrollLinkId={`acknowledgements`} items={acknowledgements} contributors={contributors} />
+				{/* Acknowledgments */}
+				<Acknowledgments
+					scrollLinkId={`acknowledgments`}
+					items={parsedFrontmatter.acknowledgments || parsedFrontmatter.acknowledgements}
+					contributors={contributors}
+				/>
 			</section>
 			{/* Toc */}
 			<RuleTableOfContents toc={tableOfContents} />


### PR DESCRIPTION
Allow for acknowledgement component to parse either `acknowledgements` or `acknowledgments` from frontmatter. The key change is here - https://github.com/act-rules/act-rules-web/pull/143/files#diff-be21b5bf63b1baeff8443e1bfcc6b40dR152

> Note: I renamed the component for consistency purposes & verified locally.

Closes Issue:
- https://github.com/act-rules/act-rules-web/issues/142