### PR TITLE
fix: sort rules in website alphabetically (ignoring backticks & casing)

### DIFF
--- a/src/pages/rules.js
+++ b/src/pages/rules.js
@@ -46,21 +46,31 @@ export default ({ location, data }) => {
 				</header>
 				{/* Rules list */}
 				<section className="content">
-					{renderedRules.map(({ node }) => {
-						const { frontmatter, fields } = node
-						return (
-							<RuleCard
-								key={frontmatter.id}
-								id={frontmatter.id}
-								name={frontmatter.name}
-								type={frontmatter.rule_type}
-								description={frontmatter.description}
-								accessibilityRequirements={JSON.parse(fields.fastmatterAttributes).accessibility_requirements}
-								inputRules={frontmatter.input_rules}
-								allRules={allRules}
-							/>
-						)
-					})}
+					{renderedRules
+						.sort((a, b) => {
+							/**
+							 * Remove markdown backticks for sort comparison
+							 */
+							const nameOfA = a.node.frontmatter.name.replace(/`/g, '').toLowerCase()
+							const nameOfB = b.node.frontmatter.name.replace(/`/g, '').toLowerCase()
+							// Reference - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
+							return nameOfA.localeCompare(nameOfB)
+						})
+						.map(({ node }) => {
+							const { frontmatter, fields } = node
+							return (
+								<RuleCard
+									key={frontmatter.id}
+									id={frontmatter.id}
+									name={frontmatter.name}
+									type={frontmatter.rule_type}
+									description={frontmatter.description}
+									accessibilityRequirements={JSON.parse(fields.fastmatterAttributes).accessibility_requirements}
+									inputRules={frontmatter.input_rules}
+									allRules={allRules}
+								/>
+							)
+						})}
 				</section>
 			</section>
 		</Layout>


### PR DESCRIPTION
Closes Issue:
- https://github.com/act-rules/act-rules-web/issues/138

> Screenshot showing that names with backticks are alphabetically sorted along with other names.
![image](https://user-images.githubusercontent.com/20978252/76305810-c0ba5780-62bd-11ea-8899-333332c48e8c.png)
