### PR TITLE
fix: reduce size between example heading and content

### DIFF
--- a/src/templates/rule.scss
+++ b/src/templates/rule.scss
@@ -12,6 +12,10 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: baseline;
+
+		> h4 {
+			margin-bottom: 0;
+		}
 	}
 
 	ul.meta,


### PR DESCRIPTION
Given the open in a new tab (for example) was introduced. The margin between example description and example title was increased. This fix reduces that.

![image](https://user-images.githubusercontent.com/20978252/81944333-85594380-95f4-11ea-90e2-d592070f4be9.png)
