### PR TITLE
fix: color contrast issue on header title anchor

### DIFF
--- a/src/components/header.scss
+++ b/src/components/header.scss
@@ -11,11 +11,6 @@ header.appHeader {
 	div.name {
 		margin: 0 1rem;
 		flex: 1;
-		a {
-			color: $accent;
-			text-decoration: none;
-			flex: 1;
-		}
 	}
 
 	div.logos {


### PR DESCRIPTION
Removed some overriding styles for an anchor element that was affecting the color contrast

Fix color contrast:
![image](https://user-images.githubusercontent.com/20978252/81944778-21834a80-95f5-11ea-9fb6-98b511d07d98.png)
