### PR TITLE
fix: ensure markdown backticks are parsed as html for used in rules

### DIFF
--- a/src/components/list-with-heading.js
+++ b/src/components/list-with-heading.js
@@ -1,23 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-const ListWithHeading = props => {
-	const { cls, heading, items = [] } = props
+const ListWithHeading = ({ cls, headingTemplate, itemKey, itemTemplate, items = [] }) => {
 	return (
 		<div className={cls}>
 			{/* title  */}
-			<h3>
-				{heading} ({items.length}):
-			</h3>
+			{headingTemplate()}
 			{/* when there are no items, show a no data note  */}
 			{(!items || !items.length) && <div className="note">No Data</div>}
 			{/* render items if they exist  */}
 			{items.length > 0 && (
 				<ul>
-					{items.map(usage => (
-						<li key={usage.slug}>
-							<a href={`/${usage.slug}`}>{usage.name}</a>
-						</li>
+					{items.map(item => (
+						<li key={item[itemKey]}>{itemTemplate(item)}</li>
 					))}
 				</ul>
 			)}
@@ -27,7 +22,9 @@ const ListWithHeading = props => {
 
 ListWithHeading.propTypes = {
 	cls: PropTypes.string,
-	heading: PropTypes.string.isRequired,
+	itemKey: PropTypes.string,
+	headingTemplate: PropTypes.func.isRequired,
+	itemTemplate: PropTypes.func.isRequired,
 	items: PropTypes.array,
 }
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -1,3 +1,4 @@
+import './glossary.scss'
 import React, { useState } from 'react'
 import classnames from 'classnames'
 import { graphql, useStaticQuery } from 'gatsby'
@@ -6,8 +7,8 @@ import Layout from '../components/layout'
 import SEO from '../components/seo'
 import glossaryUsages from './../../_data/glossary-usages.json'
 import ListWithHeading from '../components/list-with-heading'
-
-import './glossary.scss'
+import showdown from 'showdown'
+const converter = new showdown.Converter()
 
 const Glossary = ({ location }) => {
 	const { glossaryData } = useStaticQuery(
@@ -65,7 +66,7 @@ const Glossary = ({ location }) => {
 				<section className={classnames('listing', viewportSize)}>
 					{glossaryData.edges.map(({ node }) => {
 						const { frontmatter, html } = node
-
+						const items = glossaryUsages[`#${frontmatter.key}`]
 						return (
 							<article key={frontmatter.key}>
 								<section>
@@ -77,7 +78,17 @@ const Glossary = ({ location }) => {
 								</section>
 								<ListWithHeading
 									cls={`used-rules`}
-									heading={`Used In Rules`}
+									headingTemplate={() => <h3>Used In Rules: ({items ? items.length : '0'})</h3>}
+									itemKey={`slug`}
+									itemTemplate={item => (
+										<a href={`/${item.slug}`}>
+											<span
+												dangerouslySetInnerHTML={{
+													__html: converter.makeHtml(item.name),
+												}}
+											/>
+										</a>
+									)}
 									items={glossaryUsages[`#${frontmatter.key}`]}
 								/>
 							</article>

--- a/src/pages/glossary.scss
+++ b/src/pages/glossary.scss
@@ -39,6 +39,9 @@
 				a {
 					display: block;
 					text-transform: capitalize;
+					p {
+						margin: 0.25rem;
+					}
 				}
 			}
 		}

--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { graphql } from 'gatsby'
+import { graphql, Link } from 'gatsby'
 import showdown from 'showdown'
 import { format } from 'date-fns'
 import SEO from '../components/seo'
@@ -8,14 +8,10 @@ import Acknowledgments from '../components/acknowledgments'
 import AccessibilityRequirements from '../components/accessibility_requirements'
 import ListOfImplementers from '../components/list-of-implementers'
 import RuleTableOfContents from '../components/rule-table-of-contents'
-
+import ListWithHeading from '../components/list-with-heading'
+import rulesUsages from '../../_data/rules-usages.json'
 import curateGitUrl from '../../utils/curate-git-url'
-import {
-	getGlossaryUsed,
-	getRuleUsageInRules,
-	getInputRulesForRule,
-	getInputAspects,
-} from './../utils/render-fragments'
+import { getGlossaryUsed, getInputRulesForRule, getInputAspects } from './../utils/render-fragments'
 
 import implementers from '../../_data/implementers.json'
 
@@ -37,7 +33,7 @@ export default ({ location, data }) => {
 	const changelogUrl = `/rules/${ruleId}/changelog`
 	const issuesUrl = `${repositoryUrl}/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+${ruleId}+`
 	const ruleFormatInputAspects = config['rule-format-metadata']['input-aspects']
-
+	const usedInRules = rulesUsages[ruleId]
 	const validImplementers = implementers.filter(({ actMapping }) => {
 		const validMappings = actMapping.filter(({ ruleId: mappedRuleId, consistency }) => {
 			return mappedRuleId === ruleId && ['consistent', 'partially-consistent'].includes(consistency)
@@ -81,7 +77,23 @@ export default ({ location, data }) => {
 					<li>
 						<AccessibilityRequirements accessibility_requirements={parsedFrontmatter.accessibility_requirements} />
 					</li>
-					<li>{getRuleUsageInRules(ruleId)}</li>
+					<li>
+						<ListWithHeading
+							cls={`side-notes`}
+							headingTemplate={() => <span className="heading">Used in rules:</span>}
+							itemKey={`slug`}
+							itemTemplate={item => (
+								<Link to={item.slug}>
+									<span
+										dangerouslySetInnerHTML={{
+											__html: converter.makeHtml(item.name),
+										}}
+									/>
+								</Link>
+							)}
+							items={usedInRules}
+						/>
+					</li>
 					<li>{getInputAspects(frontmatter.input_aspects, ruleFormatInputAspects)}</li>
 					<li>{getInputRulesForRule(frontmatter.input_rules, allRules.edges, true)}</li>
 				</ul>

--- a/src/templates/rule.scss
+++ b/src/templates/rule.scss
@@ -30,7 +30,7 @@
 			background-color: $sep;
 			border: 1px solid $transparent;
 			text-transform: capitalize;
-			display: inline-block;
+			display: inline-flex;
 			font-weight: bold;
 			margin-top: 1em;
 			font-size: 90%;

--- a/src/utils/render-fragments.js
+++ b/src/utils/render-fragments.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
 import glossaryUsages from './../../_data/glossary-usages.json'
-import rulesUsages from './../../_data/rules-usages.json'
 
 export const getGlossaryUsed = (slug, allGlossary) => {
 	const usedKeys = getGlossaryItemsUsedInRule(slug)
@@ -102,29 +100,6 @@ export function getInputRulesForRule(inputRules, allRules, stripBasePath = false
 							</li>
 						)
 					})}
-				</ul>
-			</div>
-		</div>
-	)
-}
-
-export function getRuleUsageInRules(ruleId) {
-	const usages = rulesUsages[ruleId]
-	if (!usages) {
-		return null
-	}
-	return (
-		<div className="side-notes">
-			<div className="meta">
-				<span className="heading">Used in rules</span>
-				<ul>
-					{usages.map(usage => (
-						<li key={usage.slug}>
-							<Link key={usage.slug} to={usage.slug}>
-								{usage.name}
-							</Link>
-						</li>
-					))}
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
Decided to reuse a generic component `ListWithHeading` & refactor accordingly.