### PR TITLE
fix: remove glossary `key` from rendered pages

### DIFF
--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -72,7 +72,6 @@ const Glossary = ({ location }) => {
 									<a id={frontmatter.key} href={`#${frontmatter.key}`}>
 										<h2>{frontmatter.title}</h2>
 									</a>
-									<i>key: {frontmatter.key}</i>
 									<div dangerouslySetInnerHTML={{ __html: html }} />
 								</section>
 								<ListWithHeading

--- a/src/utils/render-fragments.js
+++ b/src/utils/render-fragments.js
@@ -31,9 +31,6 @@ export const getGlossaryUsed = (slug, allGlossary) => {
 						<a id={key} href={`#${key}`}>
 							<h3>{frontmatter.title}</h3>
 						</a>
-						<i>
-							key: <u>{key}</u>
-						</i>
 						<div dangerouslySetInnerHTML={{ __html: html }} />
 					</article>
 				)


### PR DESCRIPTION
Closes:
- https://github.com/act-rules/act-rules-web/issues/167