### PR TITLE
fix: publish website script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
           find . -maxdepth 1 ! -name 'public' ! -name '.git' ! -name '.gitignore' ! -name 'test-assets' ! -name 'testcases'  -exec rm -rf {} \;	
 
           # move generated public in the root folder and remove the empty generated public folder
-          mv public/* .
+          cp -r public/* .
           rm -R public/
 
           # commit and push to ACT R repositories master branch


### PR DESCRIPTION
Shell `mv` command did not allow for overwrites and hence failing the build like here - https://github.com/act-rules/act-rules-web/runs/693547999?check_suite_focus=true

Using `cp` allows for overwrite.