### PR TITLE
fix: open example in new tab

### DIFF
--- a/plugins/rule-example-open-in-new-tab/index.js
+++ b/plugins/rule-example-open-in-new-tab/index.js
@@ -46,6 +46,7 @@ module.exports = ({ markdownAST, markdownNode }, pluginOptions) => {
 				id="${id}" 
 				style="position:relative;">
 				<a 
+					target="_blank"
 					href="#${id}" 
 					aria-label="${testcaseHeading} permalink" 
 					class="anchor before">


### PR DESCRIPTION
Adding `target='_blank'` to open example in a new tab rather than current tab