### PR TITLE
fix: update rule template to not show `used in rules` metadata when there are none.

### DIFF
--- a/src/templates/rule.js
+++ b/src/templates/rule.js
@@ -77,23 +77,25 @@ export default ({ location, data }) => {
 					<li>
 						<AccessibilityRequirements accessibility_requirements={parsedFrontmatter.accessibility_requirements} />
 					</li>
-					<li>
-						<ListWithHeading
-							cls={`side-notes`}
-							headingTemplate={() => <span className="heading">Used in rules:</span>}
-							itemKey={`slug`}
-							itemTemplate={item => (
-								<Link to={item.slug}>
-									<span
-										dangerouslySetInnerHTML={{
-											__html: converter.makeHtml(item.name),
-										}}
-									/>
-								</Link>
-							)}
-							items={usedInRules}
-						/>
-					</li>
+					{usedInRules && usedInRules.length > 0 && (
+						<li>
+							<ListWithHeading
+								cls={`side-notes`}
+								headingTemplate={() => <span className="heading">Used in rules:</span>}
+								itemKey={`slug`}
+								itemTemplate={item => (
+									<Link to={item.slug}>
+										<span
+											dangerouslySetInnerHTML={{
+												__html: converter.makeHtml(item.name),
+											}}
+										/>
+									</Link>
+								)}
+								items={usedInRules}
+							/>
+						</li>
+					)}
 					<li>{getInputAspects(frontmatter.input_aspects, ruleFormatInputAspects)}</li>
 					<li>{getInputRulesForRule(frontmatter.input_rules, allRules.edges, true)}</li>
 				</ul>


### PR DESCRIPTION
This change gets rid of the below section for rules that are not used in other rules.

![image](https://user-images.githubusercontent.com/20978252/83101284-e7608100-a0a9-11ea-9919-a73276a4de56.png)
