### PR TITLE
chore: update checkout action to v2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - name: Set env variables
         uses: allenevans/set-env@v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
       - name: Set env variables
         uses: allenevans/set-env@v1.0.0


### PR DESCRIPTION
Updating to v2 version of `actions/checkout@v2` - See [whats new](https://github.com/actions/checkout#whats-new)

Closes issue(s):
- NA
