### PR TITLE
fix: open example in a new tab

### DIFF
--- a/plugins/rule-example-open-in-new-tab/index.js
+++ b/plugins/rule-example-open-in-new-tab/index.js
@@ -46,7 +46,6 @@ module.exports = ({ markdownAST, markdownNode }, pluginOptions) => {
 				id="${id}" 
 				style="position:relative;">
 				<a 
-					target="_blank"
 					href="#${id}" 
 					aria-label="${testcaseHeading} permalink" 
 					class="anchor before">
@@ -66,6 +65,8 @@ module.exports = ({ markdownAST, markdownNode }, pluginOptions) => {
 				${testcaseHeading}
 			</h4>
 			<a 
+				target="_blank"
+				rel="noopener noreferrer"
 				href="${testcase.url}"
 				aria-label="Open ${testcaseHeading} in a new tab">
 				${title}


### PR DESCRIPTION
Sadly this PR - https://github.com/act-rules/act-rules-web/pull/174, added the open in a new tab `target='_blank'` to a different anchor element.

This PR fixes that.