### PR TITLE
fix: ensure `DOCTYPE` is not appended if it already exists

### DIFF
--- a/build/create-testcases.js
+++ b/build/create-testcases.js
@@ -159,12 +159,12 @@ function wrapCodeWithDoctype(lang, code) {
 		xhtml: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">`,
 	}
 
-	// if given code already containst doctype - return
-	if (/<!doctype/i.test(code)) {
-		return code
-	}
-
 	if (Object.keys(doctypeMap).includes(lang)) {
+		// if given code already containst doctype - return
+		if (/<!doctype/i.test(code)) {
+			return code
+		}
+
 		return `${doctypeMap[lang]} ${code}`
 	}
 

--- a/build/create-testcases.js
+++ b/build/create-testcases.js
@@ -159,6 +159,11 @@ function wrapCodeWithDoctype(lang, code) {
 		xhtml: `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">`,
 	}
 
+	// if given code already containst doctype - return
+	if (/<!doctype/i.test(code)) {
+		return code
+	}
+
 	if (Object.keys(doctypeMap).includes(lang)) {
 		return `${doctypeMap[lang]} ${code}`
 	}


### PR DESCRIPTION
Closes:
- https://github.com/act-rules/act-rules-web/issues/183