### PR TITLE
Handle link to the text of WCAG, not just a SC

### DIFF
--- a/src/components/accessibility_requirements/index.js
+++ b/src/components/accessibility_requirements/index.js
@@ -105,6 +105,14 @@ function BasicListing({ accessibilityDocument, item, mapping, listType }) {
 			conformanceTo: 'Not required to conformance to any W3C accessibility recommendation.',
 			baseURL: 'https://www.w3.org/TR/using-aria/#',
 		},
+		'wcag-text': {
+			conformanceTo: (
+				<>
+					<strong>Required for conformance</strong> to WCAG 2.0 and above on level A and above.
+				</>
+			),
+			baseURL: 'https://www.w3.org/TR/WCAG21/#',
+		},
 	}[accessibilityDocument]
 
 	return (
@@ -200,6 +208,7 @@ export default function AccessibilityRequirements({ accessibility_requirements, 
 					switch (accessibilityDocument) {
 						case 'aria11':
 						case 'using-aria':
+						case 'wcag-text':
 							return (
 								<BasicListing
 									key={accessibilityItem}


### PR DESCRIPTION
Allow to link to any anchor in WCAG text.
Notably to non interference requirement with:
```
  wcag-text:cc5:
    title: WCAG Non-Interference
    forConformance: true
    failed: not satisfied
    passed: further testing needed
    inapplicable: further testing needed
```