### PR TITLE
fix: exclude examples of glossary from navigation

### DIFF
--- a/src/components/navigation.js
+++ b/src/components/navigation.js
@@ -14,7 +14,7 @@ const Navigation = ({ name, navigateTo, isMenuShown, onToggleMenu }) => {
 			query {
 				getTopLevelNavigation: allSitePage(
 					sort: { fields: [context___title], order: ASC }
-					filter: { context: { markdownType: { eq: "default" } } }
+					filter: { path: { regex: "/^((?!examples).)*$/" }, context: { markdownType: { eq: "default" } } }
 				) {
 					group(field: context___markdownType) {
 						fieldValue


### PR DESCRIPTION
The `examples` directory in `pages` were dynamically computed to be added to the menu structure, resulting in:

![image](https://user-images.githubusercontent.com/20978252/91179662-bad6f800-e6de-11ea-8c69-d9ee3b090332.png)

This fix, filters examples directory from being shown in navigation, but still allowing the relevant pages to be generated.