### PR TITLE
style: remove background for glossary in rule page

### DIFF
--- a/src/components/glossary.js
+++ b/src/components/glossary.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import glossaryUsages from './../../_data/glossary-usages.json'
-import './glossary.scss'
 
 const Glossary = ({ ruleId, glossaryData }) => {
 	const glossaryKeysForRule = glossaryUsages[ruleId]
@@ -26,7 +25,7 @@ const Glossary = ({ ruleId, glossaryData }) => {
 						<a id={frontmatter.key} href={`#${frontmatter.key}`}>
 							<h3>{frontmatter.title}</h3>
 						</a>
-						<div className="glossaryContent" dangerouslySetInnerHTML={{ __html: html }} />
+						<div dangerouslySetInnerHTML={{ __html: html }} />
 					</article>
 				)
 			})}

--- a/src/components/glossary.scss
+++ b/src/components/glossary.scss
@@ -1,6 +1,0 @@
-@import '../styles/variables.scss';
-
-.glossaryContent {
-	background-color: $sep;
-	padding: 1rem 0.5rem;
-}


### PR DESCRIPTION
Removing some styles as requested by @WilcoFiers 

Preview:
![image](https://user-images.githubusercontent.com/20978252/94011534-6be4b700-fd9f-11ea-84b0-442147dfa0c9.png)
