### PR TITLE
feat: add package.json to public

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,10 +1,21 @@
-const { copy } = require('fs-extra')
+const { copy, writeFile } = require('fs-extra')
 const onCreateNode = require('./gatsby/on-create-node')
 const createPages = require('./gatsby/create-pages')
 
 exports.onPreBootstrap = async () => {
 	await copy('./_data/testcases', 'public')
 	await copy('./build/earl-context.json', 'public/earl-context.json')
+
+	// Simple package.json file so that #master can be installed with NPM
+	const packageJson = JSON.stringify(
+		{
+			name: 'act-rules.github.io',
+			version: '1.0.0',
+		},
+		null,
+		2
+	)
+	await writeFile('public/package.json', packageJson)
 }
 
 exports.onCreateNode = onCreateNode


### PR DESCRIPTION
Add a package.json to the /public directory, so that the #master branch can be installed using NPM (with no dependencies).