### PR TITLE
Fix dct:title in earl-context.json

### DIFF
--- a/build/earl-context.json
+++ b/build/earl-context.json
@@ -12,6 +12,7 @@
 		"url": "dct:source",
 		"source": "dct:source",
 		"redirectedTo": "dct:source",
+		"title": "dct:title",
 		"assertions": {
 			"@reverse": "subject"
 		},
@@ -26,9 +27,6 @@
 		},
 		"pointer": {
 			"@type": "ptr:CSSSelectorPointer"
-		},
-		"title": {
-			"@type": "dct:title"
 		}
 	}
 }


### PR DESCRIPTION
`title` should have just been a short hand for `dct:title`, rather than having it as a type. `dct:title` is a property, not a class.